### PR TITLE
Add round statistics for fastest/slowest triple find and timeline

### DIFF
--- a/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
+++ b/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
@@ -6,19 +6,25 @@ import android.content.pm.ActivityInfo;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import androidx.appcompat.app.ActionBar;
+import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.TextView;
 import android.widget.ViewAnimator;
 
 import com.antsapps.triples.backend.Game;
 import com.antsapps.triples.backend.Game.GameState;
 import com.antsapps.triples.backend.Game.OnUpdateGameStateListener;
 import com.antsapps.triples.cardsview.CardsView;
+import com.antsapps.triples.stats.TimelineView;
 import com.google.firebase.analytics.FirebaseAnalytics;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public abstract class BaseGameActivity extends BaseTriplesActivity
     implements OnUpdateGameStateListener {
@@ -210,11 +216,35 @@ public abstract class BaseGameActivity extends BaseTriplesActivity
       childToDisplay = VIEW_PAUSED;
     } else if (mGameState == GameState.COMPLETED) {
       childToDisplay = VIEW_COMPLETED;
+      updateStatistics();
     } else {
       childToDisplay = VIEW_CARDS;
     }
     if (mViewAnimator.getDisplayedChild() != childToDisplay) {
       mViewAnimator.setDisplayedChild(childToDisplay);
+    }
+  }
+
+  private void updateStatistics() {
+    List<Long> findTimes = getGame().getTripleFindTimes();
+    if (!findTimes.isEmpty()) {
+      long fastest = Long.MAX_VALUE;
+      long slowest = 0;
+      long lastTime = 0;
+      for (long time : findTimes) {
+        long duration = time - lastTime;
+        fastest = Math.min(fastest, duration);
+        slowest = Math.max(slowest, duration);
+        lastTime = time;
+      }
+
+      ((TextView) findViewById(R.id.fastest_triple))
+          .setText(DateUtils.formatElapsedTime(TimeUnit.MILLISECONDS.toSeconds(fastest)));
+      ((TextView) findViewById(R.id.slowest_triple))
+          .setText(DateUtils.formatElapsedTime(TimeUnit.MILLISECONDS.toSeconds(slowest)));
+
+      ((TimelineView) findViewById(R.id.timeline))
+          .setTripleFindTimes(findTimes, getGame().getTimeElapsed());
     }
   }
 

--- a/app/src/main/java/com/antsapps/triples/backend/ArcadeGame.java
+++ b/app/src/main/java/com/antsapps/triples/backend/ArcadeGame.java
@@ -18,6 +18,7 @@ public class ArcadeGame extends Game implements OnTimerTickListener {
             -1,
             seed,
             Collections.<Card>emptyList(),
+            Collections.<Long>emptyList(),
             new Deck(new Random(seed)),
             0,
             new Date(),
@@ -31,12 +32,13 @@ public class ArcadeGame extends Game implements OnTimerTickListener {
       long id,
       long seed,
       List<Card> cardsInPlay,
+      List<Long> tripleFindTimes,
       Deck cardsInDeck,
       long timeElapsed,
       Date date,
       GameState gameState,
       int numTriplesFound) {
-    super(id, seed, cardsInPlay, cardsInDeck, timeElapsed, date, gameState);
+    super(id, seed, cardsInPlay, tripleFindTimes, cardsInDeck, timeElapsed, date, gameState);
     mNumTriplesFound = numTriplesFound;
     mTimer.addOnTimerTickListener(this);
   }

--- a/app/src/main/java/com/antsapps/triples/backend/ClassicGame.java
+++ b/app/src/main/java/com/antsapps/triples/backend/ClassicGame.java
@@ -15,6 +15,7 @@ public class ClassicGame extends Game {
             -1,
             seed,
             Collections.<Card>emptyList(),
+            Collections.<Long>emptyList(),
             new Deck(new Random(seed)),
             0,
             new Date(),
@@ -27,11 +28,12 @@ public class ClassicGame extends Game {
       long id,
       long seed,
       List<Card> cardsInPlay,
+      List<Long> tripleFindTimes,
       Deck cardsInDeck,
       long timeElapsed,
       Date date,
       GameState gameState) {
-    super(id, seed, cardsInPlay, cardsInDeck, timeElapsed, date, gameState);
+    super(id, seed, cardsInPlay, tripleFindTimes, cardsInDeck, timeElapsed, date, gameState);
   }
 
   /**

--- a/app/src/main/java/com/antsapps/triples/backend/DBAdapter.java
+++ b/app/src/main/java/com/antsapps/triples/backend/DBAdapter.java
@@ -25,10 +25,11 @@ public class DBAdapter extends SQLiteOpenHelper {
   public static final String COLUMN_TIME_ELAPSED = "time_elapsed";
   public static final String COLUMN_DATE = "date";
   public static final String COLUMN_NUM_TRIPLES_FOUND = "num_triples_found"; // ARCADE only
+  public static final String COLUMN_TRIPLE_FIND_TIMES = "triple_find_times";
   /** The name of the database file on the file system */
   private static final String DATABASE_NAME = "Triples.db";
   /** The version of the database that this class understands. */
-  private static final int DATABASE_VERSION = 4;
+  private static final int DATABASE_VERSION = 5;
 
   private static final String CREATE_CLASSIC_GAMES =
       "CREATE TABLE "
@@ -47,7 +48,9 @@ public class DBAdapter extends SQLiteOpenHelper {
           + COLUMN_TIME_ELAPSED
           + " INTEGER, " //
           + COLUMN_DATE
-          + " INTEGER)";
+          + " INTEGER, " //
+          + COLUMN_TRIPLE_FIND_TIMES
+          + " BLOB)";
   private static final String CREATE_ARCADE_GAMES =
       "CREATE TABLE "
           + TABLE_ARCADE_GAMES
@@ -67,7 +70,9 @@ public class DBAdapter extends SQLiteOpenHelper {
           + COLUMN_DATE
           + " INTEGER, " //
           + COLUMN_NUM_TRIPLES_FOUND
-          + " INTEGER)";
+          + " INTEGER, " //
+          + COLUMN_TRIPLE_FIND_TIMES
+          + " BLOB)";
   private static final String TAG = "DBAdapter";
 
   /** Constructor */
@@ -124,6 +129,18 @@ public class DBAdapter extends SQLiteOpenHelper {
         db.endTransaction();
       }
     }
+    if (oldVersion < 5) {
+      db.beginTransaction();
+      try {
+        db.execSQL("ALTER TABLE " + TABLE_CLASSIC_GAMES + " ADD COLUMN " + COLUMN_TRIPLE_FIND_TIMES + " BLOB");
+        db.execSQL("ALTER TABLE " + TABLE_ARCADE_GAMES + " ADD COLUMN " + COLUMN_TRIPLE_FIND_TIMES + " BLOB");
+        db.setTransactionSuccessful();
+      } catch (SQLException e) {
+        Log.e("DBAdapter-Upgrade", e.toString());
+      } finally {
+        db.endTransaction();
+      }
+    }
   }
 
   public void initialize(List<ClassicGame> classicGames, List<ArcadeGame> arcadeGames) {
@@ -150,7 +167,8 @@ public class DBAdapter extends SQLiteOpenHelper {
                   COLUMN_CARDS_IN_PLAY,
                   COLUMN_CARDS_IN_DECK,
                   COLUMN_TIME_ELAPSED,
-                  COLUMN_DATE
+                  COLUMN_DATE,
+                  COLUMN_TRIPLE_FIND_TIMES
                 },
                 null,
                 null,
@@ -164,6 +182,7 @@ public class DBAdapter extends SQLiteOpenHelper {
               classicGamesCursor.getLong(0),
               classicGamesCursor.getLong(2),
               Utils.cardListFromByteArray(classicGamesCursor.getBlob(3)),
+              Utils.longListFromByteArray(classicGamesCursor.getBlob(7)),
               Deck.fromByteArray(classicGamesCursor.getBlob(4)),
               classicGamesCursor.getLong(5),
               new Date(classicGamesCursor.getLong(6)),
@@ -202,6 +221,7 @@ public class DBAdapter extends SQLiteOpenHelper {
     values.put(COLUMN_CARDS_IN_DECK, game.getCardsInDeckAsByteArray());
     values.put(COLUMN_TIME_ELAPSED, game.getTimeElapsed());
     values.put(COLUMN_DATE, game.getDateStarted().getTime());
+    values.put(COLUMN_TRIPLE_FIND_TIMES, Utils.longListToByteArray(game.getTripleFindTimes()));
     return values;
   }
 
@@ -224,7 +244,8 @@ public class DBAdapter extends SQLiteOpenHelper {
                   COLUMN_CARDS_IN_DECK,
                   COLUMN_TIME_ELAPSED,
                   COLUMN_DATE,
-                  COLUMN_NUM_TRIPLES_FOUND
+                  COLUMN_NUM_TRIPLES_FOUND,
+                  COLUMN_TRIPLE_FIND_TIMES
                 },
                 null,
                 null,
@@ -238,6 +259,7 @@ public class DBAdapter extends SQLiteOpenHelper {
               arcadeGamesCursor.getLong(0),
               arcadeGamesCursor.getLong(2),
               Utils.cardListFromByteArray(arcadeGamesCursor.getBlob(3)),
+              Utils.longListFromByteArray(arcadeGamesCursor.getBlob(8)),
               Deck.fromByteArray(arcadeGamesCursor.getBlob(4)),
               arcadeGamesCursor.getLong(5),
               new Date(arcadeGamesCursor.getLong(6)),
@@ -277,6 +299,7 @@ public class DBAdapter extends SQLiteOpenHelper {
     values.put(COLUMN_TIME_ELAPSED, game.getTimeElapsed());
     values.put(COLUMN_DATE, game.getDateStarted().getTime());
     values.put(COLUMN_NUM_TRIPLES_FOUND, game.getNumTriplesFound());
+    values.put(COLUMN_TRIPLE_FIND_TIMES, Utils.longListToByteArray(game.getTripleFindTimes()));
     return values;
   }
 }

--- a/app/src/main/java/com/antsapps/triples/backend/Game.java
+++ b/app/src/main/java/com/antsapps/triples/backend/Game.java
@@ -69,6 +69,8 @@ public abstract class Game implements Comparable<Game>, OnValidTripleSelectedLis
 
   protected final List<Card> mCardsInPlay;
 
+  protected final List<Long> mTripleFindTimes;
+
   private final Set<Card> mHintedCards = Sets.newHashSet();
 
   protected final Timer mTimer;
@@ -89,6 +91,7 @@ public abstract class Game implements Comparable<Game>, OnValidTripleSelectedLis
       long id,
       long seed,
       List<Card> cardsInPlay,
+      List<Long> tripleFindTimes,
       Deck cardsInDeck,
       long timeElapsed,
       Date date,
@@ -96,6 +99,7 @@ public abstract class Game implements Comparable<Game>, OnValidTripleSelectedLis
     this.id = id;
     mRandomSeed = seed;
     mCardsInPlay = Lists.newArrayList(cardsInPlay);
+    mTripleFindTimes = Lists.newArrayList(tripleFindTimes);
     mDeck = cardsInDeck;
     mTimer = new Timer(timeElapsed);
     mDate = date;
@@ -207,6 +211,7 @@ public abstract class Game implements Comparable<Game>, OnValidTripleSelectedLis
     }
 
     mNumTriplesFound++;
+    mTripleFindTimes.add(mTimer.getElapsed());
 
     mHintedCards.clear();
     mGameRenderer.clearHintedCards();
@@ -387,6 +392,10 @@ public abstract class Game implements Comparable<Game>, OnValidTripleSelectedLis
 
   public long getTimeElapsed() {
     return mTimer.getElapsed();
+  }
+
+  public List<Long> getTripleFindTimes() {
+    return ImmutableList.copyOf(mTripleFindTimes);
   }
 
   public Date getDateStarted() {

--- a/app/src/main/java/com/antsapps/triples/backend/Utils.java
+++ b/app/src/main/java/com/antsapps/triples/backend/Utils.java
@@ -2,6 +2,7 @@ package com.antsapps.triples.backend;
 
 import com.google.common.collect.Lists;
 
+import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.List;
 
@@ -49,6 +50,26 @@ public class Utils {
       cards.add(cardFromByte(b[i]));
     }
     return cards;
+  }
+
+  public static byte[] longListToByteArray(List<Long> longs) {
+    ByteBuffer bb = ByteBuffer.allocate(longs.size() * 8);
+    for (long l : longs) {
+      bb.putLong(l);
+    }
+    return bb.array();
+  }
+
+  public static List<Long> longListFromByteArray(byte[] b) {
+    if (b == null) {
+      return Lists.newArrayList();
+    }
+    ByteBuffer bb = ByteBuffer.wrap(b);
+    List<Long> longs = Lists.newArrayList();
+    while (bb.hasRemaining()) {
+      longs.add(bb.getLong());
+    }
+    return longs;
   }
 
   private Utils() {}

--- a/app/src/main/java/com/antsapps/triples/stats/TimelineView.java
+++ b/app/src/main/java/com/antsapps/triples/stats/TimelineView.java
@@ -1,0 +1,59 @@
+package com.antsapps.triples.stats;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.util.AttributeSet;
+import android.view.View;
+
+import java.util.List;
+
+public class TimelineView extends View {
+  private List<Long> mTripleFindTimes;
+  private long mMaxTime;
+
+  public TimelineView(Context context) {
+    super(context);
+  }
+
+  public TimelineView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public void setTripleFindTimes(List<Long> tripleFindTimes, long maxTime) {
+    mTripleFindTimes = tripleFindTimes;
+    mMaxTime = maxTime;
+    invalidate();
+  }
+
+  @Override
+  protected void onDraw(Canvas canvas) {
+    super.onDraw(canvas);
+    if (mTripleFindTimes == null || mTripleFindTimes.isEmpty() || mMaxTime == 0) {
+      return;
+    }
+
+    float density = getContext().getResources().getDisplayMetrics().density;
+    float padding = 10 * density;
+
+    int width = getWidth();
+    int height = getHeight();
+    float availableWidth = width - 2 * padding;
+
+    Paint linePaint = new Paint();
+    linePaint.setColor(Color.GRAY);
+    linePaint.setStrokeWidth(2 * density);
+    canvas.drawLine(padding, height / 2, width - padding, height / 2, linePaint);
+
+    Paint pointPaint = new Paint();
+    pointPaint.setColor(0xFF33B5E5);
+    pointPaint.setStrokeWidth(8 * density);
+    pointPaint.setStrokeCap(Paint.Cap.ROUND);
+
+    for (long time : mTripleFindTimes) {
+      float x = padding + (float) time / mMaxTime * availableWidth;
+      canvas.drawPoint(x, height / 2, pointPaint);
+    }
+  }
+}

--- a/app/src/main/res/layout/game.xml
+++ b/app/src/main/res/layout/game.xml
@@ -62,6 +62,42 @@
           android:textSize="@dimen/game_paused_text_size"
           />
 
+      <GridLayout
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:columnCount="2"
+          android:rowCount="2">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/fastest_triple"
+            android:paddingRight="10dp"/>
+        <TextView
+            android:id="@+id/fastest_triple"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/slowest_triple"
+            android:paddingRight="10dp"/>
+        <TextView
+            android:id="@+id/slowest_triple"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"/>
+      </GridLayout>
+
+      <com.antsapps.triples.stats.TimelineView
+          android:id="@+id/timeline"
+          android:layout_width="match_parent"
+          android:layout_height="50dp"
+          android:layout_marginLeft="20dp"
+          android:layout_marginRight="20dp"
+          android:layout_marginTop="10dp"
+          android:layout_marginBottom="10dp"/>
+
       <Button
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,5 +68,7 @@
   <string name="classic_label">Classic</string>
   <string name="game_completed">GAME COMPLETED</string>
     <string name="hint">Hint</string>
+    <string name="fastest_triple">Fastest triple:</string>
+    <string name="slowest_triple">Slowest triple:</string>
 
 </resources>


### PR DESCRIPTION
This change implements round-specific statistics for both Classic and Arcade game modes. It includes tracking the duration of each triple find, persisting this data in the database, and displaying the fastest and slowest find times along with a timeline visualization on the game completion screen.

---
*PR created automatically by Jules for task [1155146953614371301](https://jules.google.com/task/1155146953614371301) started by @amorris13*