### PR TITLE
Prefill database with realistic data in debug mode

### DIFF
--- a/app/src/main/java/com/antsapps/triples/backend/Application.java
+++ b/app/src/main/java/com/antsapps/triples/backend/Application.java
@@ -27,19 +27,22 @@ public class Application extends OnStateChangedReporter {
     super();
     database = new DBAdapter(context);
     database.initialize(mClassicGames, mArcadeGames);
-    prefillDatabaseIfEmpty();
+    if (isDebug()) {
+      prefillDatabaseIfEmpty();
+    }
+  }
+
+  private boolean isDebug() {
+    try {
+      Class<?> buildConfigClass = Class.forName("com.antsapps.triples.BuildConfig");
+      return (Boolean) buildConfigClass.getField("DEBUG").get(null);
+    } catch (Exception e) {
+      Log.e(TAG, "Could not find BuildConfig", e);
+      return false;
+    }
   }
 
   private void prefillDatabaseIfEmpty() {
-    try {
-      Class<?> buildConfigClass = Class.forName("com.antsapps.triples.BuildConfig");
-      if (!(Boolean) buildConfigClass.getField("DEBUG").get(null)) {
-        return;
-      }
-    } catch (Exception e) {
-      Log.e(TAG, "Could not find BuildConfig", e);
-      return;
-    }
     if (mClassicGames.isEmpty()) {
       Random random = new Random();
       for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
Modified `Application.java` to include a `prefillDatabaseIfEmpty()` method that is called during initialization. This method checks if the game lists are empty and, if so, generates 10 realistic `ClassicGame` and `ArcadeGame` instances with varying dates, durations, and scores. The logic is gated by `BuildConfig.DEBUG` (checked via reflection) to ensure it only applies to debug builds.

---
*PR created automatically by Jules for task [16093814848845727477](https://jules.google.com/task/16093814848845727477) started by @amorris13*