### PR TITLE
Add UI tests and screenshot comparison support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,7 @@ android {
         applicationId "com.antsapps.triples"
         minSdkVersion 21
         targetSdkVersion 34
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -25,6 +26,14 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.4.4'
+
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.5.1'
+    androidTestImplementation 'androidx.test:core:1.5.0'
+
     implementation 'com.google.guava:guava:33.5.0-android'
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/app/src/androidTest/README.md
+++ b/app/src/androidTest/README.md
@@ -1,0 +1,48 @@
+# Triples UI Testing
+
+This project uses Espresso and AndroidX Test for UI testing, along with a custom screenshot comparison utility for snapshot testing.
+
+## Prerequisites
+
+- An Android device or emulator (emulator is recommended for consistent screenshots).
+
+## Running Tests
+
+To run the UI tests in their default "comparison" mode (comparing against reference screenshots in `app/src/androidTest/assets/goldens/`):
+
+```bash
+./gradlew connectedDebugAndroidTest
+```
+
+## Recording/Updating Golden Screenshots
+
+If you have added new UI or changed existing UI, you'll need to update the "golden" (reference) screenshots:
+
+1.  **Run tests in record mode:**
+    ```bash
+    ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.recordMode=true
+    ```
+    This will save new screenshots to the device at `/sdcard/Android/data/com.antsapps.triples/files/screenshots/`.
+
+2.  **Pull screenshots from the device:**
+    ```bash
+    adb pull /sdcard/Android/data/com.antsapps.triples/files/screenshots/ .
+    ```
+
+3.  **Move the screenshots to the assets folder:**
+    Move the `.png` files from your local `screenshots/` directory to:
+    `app/src/androidTest/assets/goldens/`
+
+4.  **Check-in the new golden images:**
+    Commit the updated PNG files along with your code changes.
+
+## Test Flows Covered
+
+- `GameFlowTest`: Covers starting new Classic and Arcade games.
+- `SettingsAndHelpTest`: Covers navigating to the Settings and Help screens.
+
+## Screenshot Comparison Logic
+
+The `ScreenshotComparator` utility performs a pixel-by-pixel comparison between the captured screenshot and the golden reference. It allows for a 1% pixel difference tolerance to account for minor rendering variations (e.g., anti-aliasing).
+
+If a comparison fails, the "failed" screenshot is saved to the device's `screenshots/` directory with a `_failed` suffix for debugging.

--- a/app/src/androidTest/java/com/antsapps/triples/GameFlowTest.java
+++ b/app/src/androidTest/java/com/antsapps/triples/GameFlowTest.java
@@ -1,0 +1,58 @@
+package com.antsapps.triples;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class GameFlowTest {
+
+    @Rule
+    public ActivityScenarioRule<ClassicGameListActivity> activityRule =
+            new ActivityScenarioRule<>(ClassicGameListActivity.class);
+
+    @Test
+    public void testClassicGameStart() {
+        // Main screen
+        ScreenshotComparator.compare("classic_list_screen");
+
+        // Start new game
+        onView(withId(R.id.new_game)).perform(click());
+
+        // Verify game screen
+        onView(withId(R.id.cards_view)).check(matches(isDisplayed()));
+        ScreenshotComparator.compare("classic_game_screen");
+    }
+
+    @Test
+    public void testArcadeGameStart() {
+        // Open drawer
+        onView(withId(R.id.drawer_layout)).perform(click());
+
+        // Select Arcade (position 1 in the list)
+        onView(withText("Arcade")).perform(click());
+
+        // Verify Arcade list screen
+        onView(withText("Arcade")).check(matches(isDisplayed()));
+        ScreenshotComparator.compare("arcade_list_screen");
+
+        // Start new game
+        onView(withId(R.id.new_game)).perform(click());
+
+        // Verify game screen
+        onView(withId(R.id.cards_view)).check(matches(isDisplayed()));
+        ScreenshotComparator.compare("arcade_game_screen");
+    }
+}

--- a/app/src/androidTest/java/com/antsapps/triples/ScreenshotComparator.java
+++ b/app/src/androidTest/java/com/antsapps/triples/ScreenshotComparator.java
@@ -1,0 +1,103 @@
+package com.antsapps.triples;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.test.core.app.Screenshot;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ScreenshotComparator {
+
+    private static final String TAG = "ScreenshotComparator";
+    private static final String GOLDEN_ASSET_PATH = "goldens/";
+    private static final float TOLERANCE = 0.01f; // 1%
+
+    public static void compare(String tag) {
+        Bundle arguments = InstrumentationRegistry.getArguments();
+        boolean recordMode = Boolean.parseBoolean(arguments.getString("recordMode", "false"));
+
+        Bitmap capturedBitmap = Screenshot.capture().getBitmap();
+
+        if (recordMode) {
+            saveBitmapToExternalStorage(capturedBitmap, tag);
+            return;
+        }
+
+        Bitmap referenceBitmap = loadReferenceBitmap(tag);
+        if (referenceBitmap == null) {
+            fail("Reference bitmap not found for tag: " + tag + ". Run in recordMode to generate it.");
+        }
+
+        compareBitmaps(referenceBitmap, capturedBitmap, tag);
+    }
+
+    private static void saveBitmapToExternalStorage(Bitmap bitmap, String tag) {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        File directory = context.getExternalFilesDir("screenshots");
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+        File file = new File(directory, tag + ".png");
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+            Log.d(TAG, "Saved screenshot to " + file.getAbsolutePath());
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to save screenshot", e);
+            fail("Failed to save screenshot for tag: " + tag);
+        }
+    }
+
+    private static Bitmap loadReferenceBitmap(String tag) {
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
+        try (InputStream is = context.getAssets().open(GOLDEN_ASSET_PATH + tag + ".png")) {
+            return BitmapFactory.decodeStream(is);
+        } catch (IOException e) {
+            Log.w(TAG, "Reference bitmap not found: " + tag, e);
+            return null;
+        }
+    }
+
+    private static void compareBitmaps(Bitmap reference, Bitmap captured, String tag) {
+        if (reference.getWidth() != captured.getWidth() || reference.getHeight() != captured.getHeight()) {
+            fail("Bitmap dimensions mismatch for tag: " + tag +
+                 ". Reference: " + reference.getWidth() + "x" + reference.getHeight() +
+                 ", Captured: " + captured.getWidth() + "x" + captured.getHeight());
+        }
+
+        int width = reference.getWidth();
+        int height = reference.getHeight();
+        int totalPixels = width * height;
+        int differentPixels = 0;
+
+        int[] refPixels = new int[totalPixels];
+        int[] capPixels = new int[totalPixels];
+        reference.getPixels(refPixels, 0, width, 0, 0, width, height);
+        captured.getPixels(capPixels, 0, width, 0, 0, width, height);
+
+        for (int i = 0; i < totalPixels; i++) {
+            if (refPixels[i] != capPixels[i]) {
+                differentPixels++;
+            }
+        }
+
+        float differenceRatio = (float) differentPixels / totalPixels;
+        Log.d(TAG, "Difference ratio for " + tag + ": " + differenceRatio);
+
+        if (differenceRatio > TOLERANCE) {
+            // If failed, save the captured bitmap for debugging
+            saveBitmapToExternalStorage(captured, tag + "_failed");
+            fail("Screenshot mismatch for tag: " + tag + ". Difference: " + (differenceRatio * 100) + "%");
+        }
+    }
+}

--- a/app/src/androidTest/java/com/antsapps/triples/SettingsAndHelpTest.java
+++ b/app/src/androidTest/java/com/antsapps/triples/SettingsAndHelpTest.java
@@ -1,0 +1,44 @@
+package com.antsapps.triples;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class SettingsAndHelpTest {
+
+    @Rule
+    public ActivityScenarioRule<ClassicGameListActivity> activityRule =
+            new ActivityScenarioRule<>(ClassicGameListActivity.class);
+
+    @Test
+    public void testHelpScreen() {
+        onView(withId(R.id.help)).perform(click());
+
+        // Verify Help screen
+        onView(withId(R.id.cards_view)).check(matches(isDisplayed()));
+        onView(withId(R.id.number_explanation)).check(matches(isDisplayed()));
+
+        ScreenshotComparator.compare("help_screen");
+    }
+
+    @Test
+    public void testSettingsScreen() {
+        onView(withId(R.id.settings)).perform(click());
+
+        // Verify Settings screen
+        ScreenshotComparator.compare("settings_screen");
+    }
+}


### PR DESCRIPTION
This PR adds a robust UI testing framework to the Triples Android app.

Key changes:
1.  **UI Testing Dependencies:** Added Espresso, AndroidX Test Runner, Rules, and JUnit extensions to `app/build.gradle`.
2.  **Screenshot Comparison Utility:** Created `ScreenshotComparator.java` which uses the AndroidX `Screenshot` API to capture the screen and compare it against reference bitmaps in `assets/goldens/`.
3.  **New UI Tests:**
    - `GameFlowTest`: Verifies starting new games in both Classic and Arcade modes.
    - `SettingsAndHelpTest`: Verifies the Settings and Help/Tutorial screens.
4.  **Recording Mode:** Added support for a `recordMode` instrumentation argument. When set to `true`, the tests will save captured screenshots to the device's storage instead of performing a comparison, allowing for easy generation of new reference images.
5.  **Documentation:** Added a `README.md` in `app/src/androidTest/` explaining how to use the new testing features, including how to pull recorded screenshots from the device using `adb`.

---
*PR created automatically by Jules for task [6634389345432450121](https://jules.google.com/task/6634389345432450121) started by @amorris13*