### PR TITLE
Smart hinting based on selected cards

### DIFF
--- a/app/src/main/java/com/antsapps/triples/backend/Game.java
+++ b/app/src/main/java/com/antsapps/triples/backend/Game.java
@@ -430,19 +430,71 @@ public abstract class Game implements Comparable<Game>, OnValidTripleSelectedLis
       return false;
     }
 
-    // Calculate hinted card
-    Set<Card> validTripleIncludingExistingHintedCards =
-        getAValidTriple(mCardsInPlay, Sets.newHashSet(mHintedCards));
-    Card cardToHint =
-        Iterables.getFirst(
-            Sets.difference(validTripleIncludingExistingHintedCards, mHintedCards), null);
-    mHintedCards.add(cardToHint);
+    Set<Card> selectedCards = mGameRenderer.getSelectedCards();
 
-    // Notify renderer & listeners
-    mGameRenderer.addHint(cardToHint);
-    for (OnUpdateCardsInPlayListener listener : mCardsInPlayListeners) {
-      listener.onCardHinted(cardToHint);
+    // Calculate target triple
+    Set<Card> targetTriple;
+    if (mHintedCards.isEmpty()) {
+      targetTriple = findValidTripleIncludingSelected(selectedCards);
+    } else {
+      targetTriple = getAValidTriple(mCardsInPlay, Sets.newHashSet(mHintedCards));
     }
+
+    if (targetTriple == null) {
+      return false;
+    }
+
+    boolean hintedNewCard = false;
+
+    // 1. Hint all selected cards in the triple that aren't hinted yet.
+    // This ensures they stay selected in the UI.
+    for (Card c : targetTriple) {
+      if (selectedCards.contains(c) && !mHintedCards.contains(c)) {
+        dispatchHint(c);
+      }
+    }
+
+    // 2. Hint at least one card that was not selected (the "actual" hint).
+    for (Card c : targetTriple) {
+      if (!mHintedCards.contains(c) && !selectedCards.contains(c)) {
+        dispatchHint(c);
+        hintedNewCard = true;
+        break;
+      }
+    }
+
+    // 3. Fallback: if we haven't hinted a new card (e.g. all remaining cards in the triple
+    // are selected), hint one of them.
+    if (!hintedNewCard && mHintedCards.size() < 3) {
+      for (Card c : targetTriple) {
+        if (!mHintedCards.contains(c)) {
+          dispatchHint(c);
+          break;
+        }
+      }
+    }
+
     return true;
+  }
+
+  private void dispatchHint(Card card) {
+    if (mHintedCards.add(card)) {
+      mGameRenderer.addHint(card);
+      for (OnUpdateCardsInPlayListener listener : mCardsInPlayListeners) {
+        listener.onCardHinted(card);
+      }
+    }
+  }
+
+  private Set<Card> findValidTripleIncludingSelected(Set<Card> selectedCards) {
+    for (int i = selectedCards.size(); i > 0; i--) {
+      for (Set<Card> subset : Sets.combinations(selectedCards, i)) {
+        Set<Card> triple = getAValidTriple(mCardsInPlay, Sets.newHashSet(subset));
+        if (triple != null) {
+          return triple;
+        }
+      }
+    }
+    return getAValidTriple(mCardsInPlay, Sets.<Card>newHashSet());
   }
 }

--- a/app/src/test/java/com/antsapps/triples/backend/HintTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/HintTest.java
@@ -1,0 +1,121 @@
+package com.antsapps.triples.backend;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class HintTest {
+
+  private static class TestGame extends Game {
+    TestGame(List<Card> cardsInPlay, Deck deck) {
+      super(0, 0, cardsInPlay, Lists.<Long>newArrayList(), deck, 0, new Date(), GameState.ACTIVE, false);
+    }
+
+    @Override
+    protected boolean isGameInValidState() {
+      return true;
+    }
+
+    @Override
+    public String getGameTypeForAnalytics() {
+      return "test";
+    }
+  }
+
+  private static class DummyRenderer implements Game.GameRenderer {
+    Set<Card> selected = Sets.newHashSet();
+    Set<Card> hinted = Sets.newHashSet();
+    @Override public void updateCardsInPlay(ImmutableList<Card> newCards) {}
+    @Override public void addHint(Card card) {
+        hinted.add(card);
+        // Mimic CardsView.addHint logic
+        selected.retainAll(hinted);
+    }
+    @Override public void clearHintedCards() { hinted.clear(); }
+    @Override public Set<Card> getSelectedCards() { return selected; }
+  }
+
+  @Test
+  public void addHint_withSelectedCardInTriple_hintsThatTriple() {
+    Card c1 = new Card(0, 0, 0, 0);
+    Card c2 = new Card(1, 1, 1, 1);
+    Card c3 = new Card(2, 2, 2, 2);
+    Card c4 = new Card(0, 0, 0, 1);
+    List<Card> cardsInPlay = Lists.newArrayList(c1, c2, c3, c4);
+    for (int i = 0; i < 8; i++) {
+        cardsInPlay.add(new Card(1, 2, 0, i % 3));
+    }
+
+    Deck deck = new Deck(Lists.<Card>newArrayList());
+    TestGame game = new TestGame(cardsInPlay, deck);
+    DummyRenderer renderer = new DummyRenderer();
+    game.setGameRenderer(renderer);
+
+    // User selected c1, which is part of triple {c1, c2, c3}
+    renderer.selected.add(c1);
+
+    game.addHint();
+
+    // c1 should be hinted (to stay selected)
+    assertThat(renderer.hinted).contains(c1);
+  }
+
+  @Test
+  public void addHint_consecutiveHints_hintsAllCardsInTriple() {
+    Card c1 = new Card(0, 0, 0, 0);
+    Card c2 = new Card(1, 1, 1, 1);
+    Card c3 = new Card(2, 2, 2, 2);
+    List<Card> cardsInPlay = Lists.newArrayList(c1, c2, c3);
+    for (int i = 0; i < 9; i++) {
+        cardsInPlay.add(new Card(1, 2, 0, i % 3));
+    }
+
+    Deck deck = new Deck(Lists.<Card>newArrayList());
+    TestGame game = new TestGame(cardsInPlay, deck);
+    DummyRenderer renderer = new DummyRenderer();
+    game.setGameRenderer(renderer);
+
+    renderer.selected.add(c1);
+
+    game.addHint(); // should hint c1
+    game.addHint(); // should hint c2 or c3
+    game.addHint(); // should hint the remaining one
+
+    assertThat(renderer.hinted).containsExactly(c1, c2, c3);
+  }
+
+  @Test
+  public void addHint_withMixedSelection_unselectsNonTripleCards() {
+    Card c1 = new Card(0, 0, 0, 0);
+    Card c2 = new Card(1, 1, 1, 1);
+    Card c3 = new Card(2, 2, 2, 2);
+    Card c4 = new Card(0, 0, 0, 1); // Not part of {c1, c2, c3}
+    List<Card> cardsInPlay = Lists.newArrayList(c1, c2, c3, c4);
+    for (int i = 0; i < 8; i++) {
+        cardsInPlay.add(new Card(1, 2, 0, i % 3));
+    }
+
+    Deck deck = new Deck(Lists.<Card>newArrayList());
+    TestGame game = new TestGame(cardsInPlay, deck);
+    DummyRenderer renderer = new DummyRenderer();
+    game.setGameRenderer(renderer);
+
+    // User selected c1 (part of triple) and c4 (not part of that triple)
+    renderer.selected.add(c1);
+    renderer.selected.add(c4);
+
+    game.addHint(); // should hint c1 and unselect c4
+
+    assertThat(renderer.hinted).contains(c1);
+    assertThat(renderer.selected).containsExactly(c1);
+  }
+}


### PR DESCRIPTION
This change improves the hinting experience by making it smarter about the user's current progress. When a hint is requested, the game now looks for a valid triple that includes as many of the currently selected cards as possible. It ensures that any correctly selected cards are included in the hinted set so they stay selected in the UI, and then reveals another card from that triple.

Key changes:
- Updated `Game.addHint()` with new logic to find and hint triples based on current selection.
- Added `findValidTripleIncludingSelected()` helper method in `Game`.
- Added `HintTest.java` with unit tests for the new behavior.

---
*PR created automatically by Jules for task [14508654857053238913](https://jules.google.com/task/14508654857053238913) started by @amorris13*