### PR TITLE
Migrate to Play Games Services v2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
-    implementation 'com.google.android.gms:play-services-games:23.1.0'
+    implementation 'com.google.android.gms:play-services-games-v2:20.1.2'
     implementation 'com.google.firebase:firebase-core:21.1.1'
     implementation 'com.google.firebase:firebase-auth:21.3.0'
     implementation 'com.google.android.gms:play-services-auth:20.5.0'

--- a/app/src/main/java/com/antsapps/triples/AchievementManager.java
+++ b/app/src/main/java/com/antsapps/triples/AchievementManager.java
@@ -1,81 +1,78 @@
 package com.antsapps.triples;
 
+import android.content.Context;
 import android.util.Log;
 
 import com.antsapps.triples.backend.Application;
 import com.antsapps.triples.backend.ArcadeGame;
 import com.antsapps.triples.backend.ClassicGame;
 import com.antsapps.triples.backend.Game;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.games.Games;
+import com.google.android.gms.games.PlayGames;
 
 import java.util.concurrent.TimeUnit;
+import android.app.Activity;
 
 public class AchievementManager {
   private static final String TAG = "AchievementManager";
 
-  public static void awardAchievementsForGame(GoogleApiClient googleApiClient, Game game) {
-    if (googleApiClient == null || !googleApiClient.isConnected() || game.areHintsUsed()) {
+  public static void awardAchievementsForGame(Context context, Game game) {
+    if (game.areHintsUsed()) {
       return;
     }
 
     if (game instanceof ClassicGame) {
-      awardClassicAchievements(googleApiClient, ((ClassicGame) game).getTimeElapsed());
+      awardClassicAchievements(context, ((ClassicGame) game).getTimeElapsed());
     } else if (game instanceof ArcadeGame) {
-      awardArcadeAchievements(googleApiClient, ((ArcadeGame) game).getNumTriplesFound());
+      awardArcadeAchievements(context, ((ArcadeGame) game).getNumTriplesFound());
     }
   }
 
-  private static void awardClassicAchievements(GoogleApiClient googleApiClient, long timeElapsed) {
+  private static void awardClassicAchievements(Context context, long timeElapsed) {
     if (timeElapsed <= TimeUnit.SECONDS.toMillis(30)) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_30S);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_30S);
     }
     if (timeElapsed <= TimeUnit.SECONDS.toMillis(45)) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_45S);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_45S);
     }
     if (timeElapsed <= TimeUnit.MINUTES.toMillis(1)) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_1M);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_1M);
     }
     if (timeElapsed <= TimeUnit.MINUTES.toMillis(2)) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_2M);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_2M);
     }
     if (timeElapsed <= TimeUnit.MINUTES.toMillis(5)) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_5M);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_5M);
     }
     if (timeElapsed <= TimeUnit.MINUTES.toMillis(10)) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_10M);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_10M);
     }
     if (timeElapsed <= TimeUnit.MINUTES.toMillis(20)) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_20M);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_20M);
     }
   }
 
-  private static void awardArcadeAchievements(GoogleApiClient googleApiClient, int triplesFound) {
+  private static void awardArcadeAchievements(Context context, int triplesFound) {
     if (triplesFound >= 25) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_25_TRIPLES);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_25_TRIPLES);
     }
     if (triplesFound >= 20) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_20_TRIPLES);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_20_TRIPLES);
     }
     if (triplesFound >= 15) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_15_TRIPLES);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_15_TRIPLES);
     }
     if (triplesFound >= 10) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_10_TRIPLES);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_10_TRIPLES);
     }
     if (triplesFound >= 5) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_5_TRIPLES);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_5_TRIPLES);
     }
     if (triplesFound >= 2) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_2_TRIPLES);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_2_TRIPLES);
     }
   }
 
-  public static void syncAchievements(GoogleApiClient googleApiClient, Application application) {
-    if (googleApiClient == null || !googleApiClient.isConnected()) {
-      return;
-    }
-
+  public static void syncAchievements(Context context, Application application) {
     int completedClassicGames = 0;
     long fastestClassicTime = Long.MAX_VALUE;
     for (ClassicGame game : application.getCompletedClassicGames()) {
@@ -85,8 +82,8 @@ public class AchievementManager {
       }
     }
     if (completedClassicGames > 0) {
-      awardClassicAchievements(googleApiClient, fastestClassicTime);
-      awardClassicCountAchievements(googleApiClient, completedClassicGames);
+      awardClassicAchievements(context, fastestClassicTime);
+      awardClassicCountAchievements(context, completedClassicGames);
     }
 
     int completedArcadeGames = 0;
@@ -98,23 +95,19 @@ public class AchievementManager {
       }
     }
     if (completedArcadeGames > 0) {
-      awardArcadeAchievements(googleApiClient, maxArcadeTriples);
-      awardArcadeCountAchievements(googleApiClient, completedArcadeGames);
+      awardArcadeAchievements(context, maxArcadeTriples);
+      awardArcadeCountAchievements(context, completedArcadeGames);
     }
   }
 
-  public static void awardCountAchievements(GoogleApiClient googleApiClient, Application application) {
-    if (googleApiClient == null || !googleApiClient.isConnected()) {
-      return;
-    }
-
+  public static void awardCountAchievements(Context context, Application application) {
     int completedClassicGames = 0;
     for (ClassicGame game : application.getCompletedClassicGames()) {
       if (!game.areHintsUsed()) {
         completedClassicGames++;
       }
     }
-    awardClassicCountAchievements(googleApiClient, completedClassicGames);
+    awardClassicCountAchievements(context, completedClassicGames);
 
     int completedArcadeGames = 0;
     for (ArcadeGame game : application.getCompletedArcadeGames()) {
@@ -122,54 +115,54 @@ public class AchievementManager {
         completedArcadeGames++;
       }
     }
-    awardArcadeCountAchievements(googleApiClient, completedArcadeGames);
+    awardArcadeCountAchievements(context, completedArcadeGames);
   }
 
-  private static void awardClassicCountAchievements(GoogleApiClient googleApiClient, int count) {
+  private static void awardClassicCountAchievements(Context context, int count) {
     if (count >= 5000) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_5000);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_5000);
     }
     if (count >= 1000) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_1000);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_1000);
     }
     if (count >= 500) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_500);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_500);
     }
     if (count >= 100) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_100);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_100);
     }
     if (count >= 50) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_50);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_50);
     }
     if (count >= 10) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_10);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_10);
     }
     if (count >= 1) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.CLASSIC_1);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.CLASSIC_1);
     }
   }
 
-  private static void awardArcadeCountAchievements(GoogleApiClient googleApiClient, int count) {
+  private static void awardArcadeCountAchievements(Context context, int count) {
     if (count >= 5000) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_5000);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_5000);
     }
     if (count >= 1000) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_1000);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_1000);
     }
     if (count >= 500) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_500);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_500);
     }
     if (count >= 100) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_100);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_100);
     }
     if (count >= 50) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_50);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_50);
     }
     if (count >= 10) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_10);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_10);
     }
     if (count >= 1) {
-      Games.Achievements.unlock(googleApiClient, GamesServices.Achievement.ARCADE_1);
+      PlayGames.getAchievementsClient((Activity) context).unlock(GamesServices.Achievement.ARCADE_1);
     }
   }
 }

--- a/app/src/main/java/com/antsapps/triples/ArcadeGameActivity.java
+++ b/app/src/main/java/com/antsapps/triples/ArcadeGameActivity.java
@@ -13,11 +13,9 @@ import com.antsapps.triples.backend.ArcadeGame;
 import com.antsapps.triples.backend.Card;
 import com.antsapps.triples.backend.Game;
 import com.antsapps.triples.backend.OnTimerTickListener;
-import com.google.android.gms.common.api.ResultCallback;
-import com.google.android.gms.games.Games;
-import com.google.android.gms.games.GamesStatusCodes;
+import com.google.android.gms.games.GamesClientStatusCodes;
+import com.google.android.gms.games.PlayGames;
 import com.google.android.gms.games.leaderboard.LeaderboardVariant;
-import com.google.android.gms.games.leaderboard.Leaderboards;
 import com.google.common.collect.ImmutableList;
 
 import java.util.concurrent.TimeUnit;
@@ -93,43 +91,44 @@ public class ArcadeGameActivity extends BaseGameActivity
       return;
     }
 
-    Games.Leaderboards.submitScoreImmediate(
-            mGoogleApiClient, GamesServices.Leaderboard.ARCADE, mGame.getNumTriplesFound())
-        .setResultCallback(
-            new ResultCallback<Leaderboards.SubmitScoreResult>() {
-              @Override
-              public void onResult(@NonNull Leaderboards.SubmitScoreResult submitScoreResult) {
-                String message = null;
-                switch (submitScoreResult.getStatus().getStatusCode()) {
-                  case GamesStatusCodes.STATUS_OK:
-                    if (submitScoreResult
-                        .getScoreData()
-                        .getScoreResult(LeaderboardVariant.TIME_SPAN_ALL_TIME)
-                        .newBest) {
-                      message = "Congratulations! That's your best score ever.";
-                    } else if (submitScoreResult
-                        .getScoreData()
-                        .getScoreResult(LeaderboardVariant.TIME_SPAN_WEEKLY)
-                        .newBest) {
-                      message = "Well Done! That's your best score this week.";
-                    } else if (submitScoreResult
-                        .getScoreData()
-                        .getScoreResult(LeaderboardVariant.TIME_SPAN_DAILY)
-                        .newBest) {
-                      message = "Nice! That's your best score today.";
-                    } else {
-                      message = "You've done better today - keep trying!";
-                    }
-                    break;
-                  case GamesStatusCodes.STATUS_NETWORK_ERROR_OPERATION_DEFERRED:
-                    message = "Score will be submitted when next connected.";
-                    break;
-                  default:
-                    message = "Score could not be submitted";
-                    break;
+    PlayGames.getLeaderboardsClient(this)
+        .submitScoreImmediate(GamesServices.Leaderboard.ARCADE, mGame.getNumTriplesFound())
+        .addOnCompleteListener(
+            task -> {
+              String message = null;
+              if (task.isSuccessful()) {
+                com.google.android.gms.games.leaderboard.ScoreSubmissionData
+                    submitScoreResult = task.getResult();
+                if (submitScoreResult
+                    .getScoreResult(LeaderboardVariant.TIME_SPAN_ALL_TIME)
+                    .newBest) {
+                  message = "Congratulations! That's your best score ever.";
+                } else if (submitScoreResult
+                    .getScoreResult(LeaderboardVariant.TIME_SPAN_WEEKLY)
+                    .newBest) {
+                  message = "Well Done! That's your best score this week.";
+                } else if (submitScoreResult
+                    .getScoreResult(LeaderboardVariant.TIME_SPAN_DAILY)
+                    .newBest) {
+                  message = "Nice! That's your best score today.";
+                } else {
+                  message = "You've done better today - keep trying!";
                 }
-                Toast.makeText(ArcadeGameActivity.this, message, Toast.LENGTH_LONG).show();
+              } else {
+                Exception e = task.getException();
+                if (e instanceof com.google.android.gms.common.api.ApiException) {
+                  int statusCode =
+                      ((com.google.android.gms.common.api.ApiException) e).getStatusCode();
+                  if (statusCode == GamesClientStatusCodes.NETWORK_ERROR_OPERATION_FAILED) {
+                    message = "Score will be submitted when next connected.";
+                  } else {
+                    message = "Score could not be submitted";
+                  }
+                } else {
+                  message = "Score could not be submitted";
+                }
               }
+              Toast.makeText(ArcadeGameActivity.this, message, Toast.LENGTH_LONG).show();
             });
   }
 

--- a/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
+++ b/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
@@ -268,8 +268,8 @@ public abstract class BaseGameActivity extends BaseTriplesActivity
     logGameEvent(AnalyticsConstants.Event.FINISH_GAME);
     if (isSignedIn()) {
       submitScore();
-      AchievementManager.awardAchievementsForGame(mGoogleApiClient, getGame());
-      AchievementManager.awardCountAchievements(mGoogleApiClient, Application.getInstance(this));
+      AchievementManager.awardAchievementsForGame(this, getGame());
+      AchievementManager.awardCountAchievements(this, Application.getInstance(this));
     } else {
       shouldSubmitScoreOnSignIn = true;
     }

--- a/app/src/main/java/com/antsapps/triples/BaseTriplesActivity.java
+++ b/app/src/main/java/com/antsapps/triples/BaseTriplesActivity.java
@@ -8,16 +8,12 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.widget.Toast;
 
-import com.google.android.gms.auth.api.Auth;
+import com.google.android.gms.auth.api.signin.GoogleSignIn;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
+import com.google.android.gms.auth.api.signin.GoogleSignInClient;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
-import com.google.android.gms.auth.api.signin.GoogleSignInResult;
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.common.api.OptionalPendingResult;
-import com.google.android.gms.common.api.ResultCallback;
-import com.google.android.gms.common.api.Status;
-import com.google.android.gms.games.Games;
+import com.google.android.gms.games.PlayGames;
+import com.google.android.gms.games.PlayGamesSdk;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.analytics.FirebaseAnalytics;
@@ -27,8 +23,7 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.GoogleAuthProvider;
 
-public abstract class BaseTriplesActivity extends AppCompatActivity
-    implements GoogleApiClient.OnConnectionFailedListener, GoogleApiClient.ConnectionCallbacks {
+public abstract class BaseTriplesActivity extends AppCompatActivity {
 
   public interface OnSignInListener {
     void onSignInStateChanged(boolean signedInAndConnected);
@@ -39,31 +34,14 @@ public abstract class BaseTriplesActivity extends AppCompatActivity
 
   protected FirebaseAnalytics mFirebaseAnalytics;
   private FirebaseAuth mFirebaseAuth;
-  protected GoogleApiClient mGoogleApiClient;
-  protected GoogleSignInAccount mGoogleSignInAccount;
+  protected boolean mIsSignedIn = false;
 
   @Nullable private OnSignInListener mSignInListener;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-
-    // Configure sign-in to request the user's ID, email address, and basic
-    // profile. ID and basic profile are included in DEFAULT_SIGN_IN.
-    GoogleSignInOptions gso =
-        new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_GAMES_SIGN_IN)
-            .requestIdToken(getString(R.string.default_web_client_id))
-            .build();
-
-    // Build a GoogleApiClient with access to the Google Sign-In API and the
-    // options specified by gso.
-    mGoogleApiClient =
-        new GoogleApiClient.Builder(this)
-            .enableAutoManage(this /* FragmentActivity */, this /* OnConnectionFailedListener */)
-            .addApi(Auth.GOOGLE_SIGN_IN_API, gso)
-            .addApi(Games.API)
-            .addConnectionCallbacks(this)
-            .build();
+    PlayGamesSdk.initialize(this);
 
     mFirebaseAuth = FirebaseAuth.getInstance();
     mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
@@ -72,60 +50,65 @@ public abstract class BaseTriplesActivity extends AppCompatActivity
   @Override
   public void onStart() {
     super.onStart();
-
-    OptionalPendingResult<GoogleSignInResult> opr =
-        Auth.GoogleSignInApi.silentSignIn(mGoogleApiClient);
-    if (opr.isDone()) {
-      // If the user's cached credentials are valid, the OptionalPendingResult will be "done"
-      // and the GoogleSignInResult will be available instantly.
-      Log.d(TAG, "Got cached sign-in. isConnected: " + mGoogleApiClient.isConnected());
-      GoogleSignInResult result = opr.get();
-      handleSignInResult(result);
-    } else {
-      // If the user has not previously signed in on this device or the sign-in has expired,
-      // this asynchronous branch will attempt to sign in the user silently.  Cross-device
-      // single sign-on will occur in this branch.
-      opr.setResultCallback(
-          new ResultCallback<GoogleSignInResult>() {
-            @Override
-            public void onResult(GoogleSignInResult googleSignInResult) {
-              handleSignInResult(googleSignInResult);
-            }
-          });
-    }
   }
 
   @Override
   protected void onResume() {
     super.onResume();
+    signInSilently();
+  }
+
+  private void signInSilently() {
+    PlayGames.getGamesSignInClient(this)
+        .isAuthenticated()
+        .addOnCompleteListener(
+            task -> {
+              boolean isAuthenticated = (task.isSuccessful() && task.getResult().isAuthenticated());
+              if (isAuthenticated) {
+                Log.d(TAG, "signInSilently: success");
+                mIsSignedIn = true;
+                mFirebaseAnalytics.logEvent(AnalyticsConstants.Event.SIGN_IN, null);
+                onSignInSucceeded();
+                // We still want to sign into Firebase if possible.
+                // PGS v2 doesn't give us the ID token directly for Firebase.
+                // For now, we prioritize PGS v2 migration.
+                fetchTokenAndSignInToFirebase();
+              } else {
+                Log.d(TAG, "signInSilently: failure");
+                mIsSignedIn = false;
+                onSignInFailed();
+              }
+            });
+  }
+
+  private void fetchTokenAndSignInToFirebase() {
+    GoogleSignInOptions gso =
+        new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_GAMES_SIGN_IN)
+            .requestIdToken(getString(R.string.default_web_client_id))
+            .build();
+    GoogleSignInClient googleSignInClient = GoogleSignIn.getClient(this, gso);
+    googleSignInClient
+        .silentSignIn()
+        .addOnCompleteListener(
+            this,
+            task -> {
+              if (task.isSuccessful()) {
+                GoogleSignInAccount account = task.getResult();
+                firebaseAuthWithGoogle(account);
+              }
+            });
   }
 
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
 
-    // Result returned from launching the Intent from GoogleSignInApi.getSignInIntent(...);
     if (requestCode == RC_SIGN_IN) {
-      GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(data);
-      Log.d(TAG, "onActivityResult. isConnected: " + mGoogleApiClient.isConnected());
-      handleSignInResult(result);
-    }
-  }
-
-  private void handleSignInResult(GoogleSignInResult result) {
-    Log.d(
-        TAG,
-        "handleSignInResult:"
-            + result.isSuccess()
-            + " isConnected: "
-            + mGoogleApiClient.isConnected());
-    if (result.isSuccess()) {
-      mGoogleSignInAccount = result.getSignInAccount();
-      firebaseAuthWithGoogle(mGoogleSignInAccount);
-      mFirebaseAnalytics.logEvent(AnalyticsConstants.Event.SIGN_IN, null);
-      onSignInSucceeded();
-    } else {
-      onSignInFailed();
+      Task<GoogleSignInAccount> task = GoogleSignIn.getSignedInAccountFromIntent(data);
+      if (task.isSuccessful()) {
+        firebaseAuthWithGoogle(task.getResult());
+        signInSilently();
+      }
     }
   }
 
@@ -169,32 +152,35 @@ public abstract class BaseTriplesActivity extends AppCompatActivity
     if (mSignInListener != null) {
       mSignInListener.onSignInStateChanged(isSignedIn());
     }
-    AchievementManager.syncAchievements(mGoogleApiClient, com.antsapps.triples.backend.Application.getInstance(this));
+    AchievementManager.syncAchievements(this, com.antsapps.triples.backend.Application.getInstance(this));
   }
 
   public void signIn() {
-    Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(mGoogleApiClient);
-    startActivityForResult(signInIntent, RC_SIGN_IN);
+    PlayGames.getGamesSignInClient(this)
+        .signIn()
+        .addOnCompleteListener(
+            task -> {
+              if (task.isSuccessful() && task.getResult().isAuthenticated()) {
+                mIsSignedIn = true;
+                onSignInSucceeded();
+              } else {
+                mIsSignedIn = false;
+                onSignInFailed();
+              }
+            });
   }
 
   public boolean isSignedIn() {
-    return mGoogleApiClient != null
-        && mGoogleApiClient.isConnected()
-        && mGoogleApiClient.hasConnectedApi(Games.API);
+    return mIsSignedIn;
   }
 
   protected void signOut() {
+    // Note: PGS v2 does not support programmatic sign out.
+    // We can sign out from Firebase.
     mFirebaseAuth.signOut();
-    Games.signOut(mGoogleApiClient);
     mFirebaseAnalytics.logEvent(AnalyticsConstants.Event.SIGN_OUT, null);
-    Auth.GoogleSignInApi.signOut(mGoogleApiClient)
-        .setResultCallback(
-            new ResultCallback<Status>() {
-              @Override
-              public void onResult(Status status) {
-                onSignOut();
-              }
-            });
+    mIsSignedIn = false;
+    onSignOut();
   }
 
   protected void onSignOut() {
@@ -204,35 +190,7 @@ public abstract class BaseTriplesActivity extends AppCompatActivity
   }
 
   @Override
-  public void onConnected(@Nullable Bundle bundle) {
-    if (mSignInListener != null) {
-      mSignInListener.onSignInStateChanged(isSignedIn());
-    }
-  }
-
-  @Override
-  public void onConnectionSuspended(int i) {
-    if (mSignInListener != null) {
-      mSignInListener.onSignInStateChanged(isSignedIn());
-    }
-  }
-
-  @Override
-  public void onConnectionFailed(ConnectionResult connectionResult) {
-    // An unresolvable error has occurred and Google APIs (including Sign-In) will not
-    // be available.
-    Log.d(TAG, "onConnectionFailed:" + connectionResult);
-    if (mSignInListener != null) {
-      mSignInListener.onSignInStateChanged(isSignedIn());
-    }
-  }
-
-  @Override
   protected void onStop() {
     super.onStop();
-  }
-
-  public GoogleApiClient getApiClient() {
-    return mGoogleApiClient;
   }
 }

--- a/app/src/main/java/com/antsapps/triples/ClassicGameActivity.java
+++ b/app/src/main/java/com/antsapps/triples/ClassicGameActivity.java
@@ -13,11 +13,9 @@ import com.antsapps.triples.backend.Card;
 import com.antsapps.triples.backend.ClassicGame;
 import com.antsapps.triples.backend.Game;
 import com.antsapps.triples.backend.OnTimerTickListener;
-import com.google.android.gms.common.api.ResultCallback;
-import com.google.android.gms.games.Games;
-import com.google.android.gms.games.GamesStatusCodes;
+import com.google.android.gms.games.GamesClientStatusCodes;
+import com.google.android.gms.games.PlayGames;
 import com.google.android.gms.games.leaderboard.LeaderboardVariant;
-import com.google.android.gms.games.leaderboard.Leaderboards;
 import com.google.common.collect.ImmutableList;
 
 import java.util.concurrent.TimeUnit;
@@ -90,43 +88,43 @@ public class ClassicGameActivity extends BaseGameActivity
     if (mGame.getGameState() != Game.GameState.COMPLETED || mGame.areHintsUsed()) {
       return;
     }
-    Games.Leaderboards.submitScoreImmediate(
-            mGoogleApiClient, GamesServices.Leaderboard.CLASSIC, mGame.getTimeElapsed())
-        .setResultCallback(
-            new ResultCallback<Leaderboards.SubmitScoreResult>() {
-              @Override
-              public void onResult(@NonNull Leaderboards.SubmitScoreResult submitScoreResult) {
-                String message = null;
-                switch (submitScoreResult.getStatus().getStatusCode()) {
-                  case GamesStatusCodes.STATUS_OK:
-                    if (submitScoreResult
-                        .getScoreData()
-                        .getScoreResult(LeaderboardVariant.TIME_SPAN_ALL_TIME)
-                        .newBest) {
-                      message = "Congratulations! That's your best score ever.";
-                    } else if (submitScoreResult
-                        .getScoreData()
-                        .getScoreResult(LeaderboardVariant.TIME_SPAN_WEEKLY)
-                        .newBest) {
-                      message = "Well Done! That's your best score this week.";
-                    } else if (submitScoreResult
-                        .getScoreData()
-                        .getScoreResult(LeaderboardVariant.TIME_SPAN_DAILY)
-                        .newBest) {
-                      message = "Nice! That's your best score today.";
-                    } else {
-                      message = "You've done better today - keep trying!";
-                    }
-                    break;
-                  case GamesStatusCodes.STATUS_NETWORK_ERROR_OPERATION_DEFERRED:
-                    message = "Score will be submitted when next connected.";
-                    break;
-                  default:
-                    message = "Score could not be submitted";
-                    break;
+    PlayGames.getLeaderboardsClient(this)
+        .submitScoreImmediate(GamesServices.Leaderboard.CLASSIC, mGame.getTimeElapsed())
+        .addOnCompleteListener(
+            task -> {
+              String message = null;
+              if (task.isSuccessful()) {
+                com.google.android.gms.games.leaderboard.ScoreSubmissionData
+                    submitScoreResult = task.getResult();
+                if (submitScoreResult
+                    .getScoreResult(LeaderboardVariant.TIME_SPAN_ALL_TIME)
+                    .newBest) {
+                  message = "Congratulations! That's your best score ever.";
+                } else if (submitScoreResult
+                    .getScoreResult(LeaderboardVariant.TIME_SPAN_WEEKLY)
+                    .newBest) {
+                  message = "Well Done! That's your best score this week.";
+                } else if (submitScoreResult
+                    .getScoreResult(LeaderboardVariant.TIME_SPAN_DAILY)
+                    .newBest) {
+                  message = "Nice! That's your best score today.";
+                } else {
+                  message = "You've done better today - keep trying!";
                 }
-                Toast.makeText(ClassicGameActivity.this, message, Toast.LENGTH_LONG).show();
+              } else {
+                Exception e = task.getException();
+                if (e instanceof com.google.android.gms.common.api.ApiException) {
+                  int statusCode = ((com.google.android.gms.common.api.ApiException) e).getStatusCode();
+                  if (statusCode == GamesClientStatusCodes.NETWORK_ERROR_OPERATION_FAILED) {
+                    message = "Score will be submitted when next connected.";
+                  } else {
+                    message = "Score could not be submitted";
+                  }
+                } else {
+                  message = "Score could not be submitted";
+                }
               }
+              Toast.makeText(ClassicGameActivity.this, message, Toast.LENGTH_LONG).show();
             });
   }
 

--- a/app/src/main/java/com/antsapps/triples/stats/StatisticsGamesServicesView.java
+++ b/app/src/main/java/com/antsapps/triples/stats/StatisticsGamesServicesView.java
@@ -9,7 +9,7 @@ import android.widget.FrameLayout;
 
 import com.antsapps.triples.BaseTriplesActivity;
 import com.antsapps.triples.R;
-import com.google.android.gms.games.Games;
+import com.google.android.gms.games.PlayGames;
 
 class StatisticsGamesServicesView extends FrameLayout
     implements View.OnClickListener, BaseTriplesActivity.OnSignInListener {
@@ -47,9 +47,12 @@ class StatisticsGamesServicesView extends FrameLayout
       // start the asynchronous sign in flow
       mActivity.signIn();
     } else if (view.getId() == R.id.leaderboards) {
-      Intent leaderboardIntent =
-          Games.Leaderboards.getLeaderboardIntent(mActivity.getApiClient(), mLeaderboardId);
-      ((Activity) getContext()).startActivityForResult(leaderboardIntent, 26);
+      PlayGames.getLeaderboardsClient(mActivity)
+          .getLeaderboardIntent(mLeaderboardId)
+          .addOnSuccessListener(
+              intent -> {
+                ((Activity) getContext()).startActivityForResult(intent, 26);
+              });
     }
   }
 


### PR DESCRIPTION
This change migrates the application from the deprecated Google Play Games Services (PGS) v1 SDK (using GoogleApiClient) to the modern PGS v2 SDK.

Key changes:
- Dependency update in `app/build.gradle` to `com.google.android.gms:play-services-games-v2:20.1.2`.
- Initialization of PGS v2 in `BaseTriplesActivity.onCreate`.
- Refactored authentication flow in `BaseTriplesActivity` to use `GamesSignInClient` for PGS authentication and `GoogleSignInClient` (silently) for Firebase Authentication.
- Updated `AchievementManager`, `ClassicGameActivity`, `ArcadeGameActivity`, and `StatisticsGamesServicesView` to use `PlayGames.getAchievementsClient()` and `PlayGames.getLeaderboardsClient()` instead of the legacy static `Games` methods and `GoogleApiClient`.
- Cleaned up imports and removed unused `GoogleApiClient` listener implementations.
- Ensured compilation success and verified the new Task-based API usage.

---
*PR created automatically by Jules for task [17116397321512540439](https://jules.google.com/task/17116397321512540439) started by @amorris13*