### PR TITLE
Update animation duration summary in real-time while sliding

### DIFF
--- a/app/src/main/java/com/antsapps/triples/SettingsFragment.java
+++ b/app/src/main/java/com/antsapps/triples/SettingsFragment.java
@@ -21,9 +21,8 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
     SeekBarPreference animationDurationPref = findPreference(getString(R.string.pref_animation_speed));
     if (animationDurationPref != null) {
-      animationDurationPref.setSummaryProvider(
-          (Preference.SummaryProvider<SeekBarPreference>)
-              preference -> getString(R.string.pref_animation_duration_summary, preference.getValue()));
+      animationDurationPref.setSummary(
+          getString(R.string.pref_animation_duration_summary, animationDurationPref.getValue()));
     }
   }
 
@@ -40,6 +39,9 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
   @Override
   public boolean onPreferenceChange(Preference preference, Object newValue) {
+    if (preference.getKey().equals(getString(R.string.pref_animation_speed))) {
+      preference.setSummary(getString(R.string.pref_animation_duration_summary, (Integer) newValue));
+    }
     Bundle bundle = new Bundle();
     bundle.putString(AnalyticsConstants.Param.SETTING_NAME, preference.getKey());
     bundle.putString(AnalyticsConstants.Param.SETTING_VALUE, String.valueOf(newValue));

--- a/app/src/test/java/com/antsapps/triples/AnimationDurationSummaryTest.java
+++ b/app/src/test/java/com/antsapps/triples/AnimationDurationSummaryTest.java
@@ -1,0 +1,35 @@
+package com.antsapps.triples;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.preference.SeekBarPreference;
+import androidx.test.core.app.ActivityScenario;
+import org.junit.Test;
+import org.robolectric.annotation.Config;
+
+public class AnimationDurationSummaryTest extends BaseRobolectricTest {
+
+    @Test
+    public void testAnimationDurationSummaryUpdates() {
+        try (ActivityScenario<SettingsActivity> scenario = ActivityScenario.launch(SettingsActivity.class)) {
+            scenario.onActivity(activity -> {
+                SettingsFragment fragment = (SettingsFragment) activity.getSupportFragmentManager().findFragmentByTag(".SettingsFragment");
+                SeekBarPreference animationDurationPref = fragment.findPreference(activity.getString(R.string.pref_animation_speed));
+
+                assertThat(animationDurationPref).isNotNull();
+
+                // Initial value
+                int initialValue = animationDurationPref.getValue();
+                assertThat(animationDurationPref.getSummary().toString()).isEqualTo(activity.getString(R.string.pref_animation_duration_summary, initialValue));
+
+                // Change value and verify summary updates
+                int newValue = 500;
+                // In a real app, sliding the seekbar triggers onPreferenceChange.
+                // We simulate this by calling the listener directly.
+                fragment.onPreferenceChange(animationDurationPref, newValue);
+
+                assertThat(animationDurationPref.getSummary().toString()).isEqualTo(activity.getString(R.string.pref_animation_duration_summary, newValue));
+            });
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes an issue where the time subtitle (summary) for the Animation duration setting does not update while sliding the seekbar.

Changes:
- Modified `SettingsFragment.java` to update the summary of the animation duration `SeekBarPreference` manually in the `onPreferenceChange` listener.
- Removed the redundant `SummaryProvider` for the animation duration preference.
- Added a unit test `AnimationDurationSummaryTest.java` to verify that the summary updates correctly when `onPreferenceChange` is triggered.

---
*PR created automatically by Jules for task [8030032473496863670](https://jules.google.com/task/8030032473496863670) started by @amorris13*