### PR TITLE
Refine navigation and resume logic

### DIFF
--- a/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
+++ b/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
@@ -147,9 +147,6 @@ public abstract class BaseGameActivity extends BaseTriplesActivity
       startActivity(settingsIntent);
       return true;
     } else if (itemId == android.R.id.home) {// app icon in action bar clicked; go up one level
-      Intent intent = new Intent(this, MainActivity.class);
-      intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-      startActivity(intent);
       finish();
       return true;
     }
@@ -418,6 +415,7 @@ public abstract class BaseGameActivity extends BaseTriplesActivity
     Intent newGameIntent = createNewGame();
     logGameEvent(AnalyticsConstants.Event.NEW_GAME);
     startActivity(newGameIntent);
+    finish();
   }
 
   protected abstract Intent createNewGame();

--- a/app/src/main/java/com/antsapps/triples/MainActivity.java
+++ b/app/src/main/java/com/antsapps/triples/MainActivity.java
@@ -100,7 +100,7 @@ public class MainActivity extends BaseTriplesActivity {
 
   private void updateResumeButtons() {
     ClassicGame classicGame = Iterables.getFirst(mApplication.getCurrentClassicGames(), null);
-    if (classicGame != null) {
+    if (classicGame != null && !classicGame.getTripleFindTimes().isEmpty()) {
       mClassicResumeButton.setVisibility(View.VISIBLE);
       mClassicResumeButton.setText(getString(R.string.resume_game_classic_format, classicGame.getCardsRemaining()));
       mClassicNewGameButton.setText(R.string.start_again);
@@ -112,7 +112,7 @@ public class MainActivity extends BaseTriplesActivity {
     mClassicStatisticsButton.setText(getString(R.string.statistics_format, numClassicCompleted));
 
     ArcadeGame arcadeGame = Iterables.getFirst(mApplication.getCurrentArcadeGames(), null);
-    if (arcadeGame != null) {
+    if (arcadeGame != null && !arcadeGame.getTripleFindTimes().isEmpty()) {
       mArcadeResumeButton.setVisibility(View.VISIBLE);
       mArcadeResumeButton.setText(getString(R.string.resume_game_arcade_format, arcadeGame.getNumTriplesFound()));
       mArcadeNewGameButton.setText(R.string.start_again);


### PR DESCRIPTION
This change addresses three related navigation and UI issues:
1. Navigating back from a game to the main screen now uses the back stack (finish()) instead of creating a new MainActivity.
2. Starting a new game from a completed game now replaces that game on the back stack.
3. The 'Resume' button on the main screen is only shown if at least one triple has been found in the current game, providing a cleaner UI and preventing 'resuming' essentially empty games.

---
*PR created automatically by Jules for task [9123611654317024728](https://jules.google.com/task/9123611654317024728) started by @amorris13*