### PR TITLE
Enhance Game Completed Screen and Statistics Display

### DIFF
--- a/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
+++ b/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
@@ -333,15 +333,17 @@ public abstract class BaseGameActivity extends BaseTriplesActivity
         lastTime = time;
       }
 
-      TextView labelTv = (TextView) findViewById(R.id.game_output_label);
-      TextView valueTv = (TextView) findViewById(R.id.game_output_value);
+      TextView outputTv = (TextView) findViewById(R.id.game_output);
       Game game = getGame();
       if (game instanceof ClassicGame) {
-        labelTv.setText(R.string.time_taken_field);
-        valueTv.setText(formatElapsedTime(game.getTimeElapsed()));
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(game.getTimeElapsed());
+        if (seconds < 60) {
+          outputTv.setText(getString(R.string.classic_completed_stats_seconds_format, seconds));
+        } else {
+          outputTv.setText(getString(R.string.classic_completed_stats_format, seconds / 60, seconds % 60));
+        }
       } else if (game instanceof ArcadeGame) {
-        labelTv.setText(R.string.triples_found_field);
-        valueTv.setText(String.valueOf(((ArcadeGame) game).getNumTriplesFound()));
+        outputTv.setText(getString(R.string.arcade_completed_stats, ((ArcadeGame) game).getNumTriplesFound()));
       }
 
       TextView fastestTv = (TextView) findViewById(R.id.fastest_triple);

--- a/app/src/main/res/layout/game.xml
+++ b/app/src/main/res/layout/game.xml
@@ -63,23 +63,21 @@
           android:textSize="@dimen/game_paused_text_size"
           />
 
+      <TextView
+          android:id="@+id/game_output"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:textSize="24sp"
+          android:textStyle="bold"
+          android:layout_marginTop="8dp"
+          android:layout_marginBottom="8dp"/>
+
       <GridLayout
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:columnCount="2"
-          android:rowCount="3"
+          android:rowCount="2"
           android:paddingBottom="4dp">
-        <TextView
-            android:id="@+id/game_output_label"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingRight="10dp"/>
-        <TextView
-            android:id="@+id/game_output_value"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textStyle="bold"
-            android:paddingRight="4dp"/>
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,9 @@
     <string name="slowest_triple">Slowest triple:</string>
     <string name="time_taken_field">Time taken:</string>
     <string name="triples_found_field">Triples found:</string>
+    <string name="arcade_completed_stats">%1$d triples</string>
+    <string name="classic_completed_stats_format">%1$dm %2$02ds</string>
+    <string name="classic_completed_stats_seconds_format">%1$ds</string>
 
     <string name="hint_confirmation_title">Use a hint?</string>
     <string name="hint_confirmation_message">Are you sure you want to use a hint? This game will not count towards your statistics or leaderboards.</string>


### PR DESCRIPTION
Improved the game completion experience by adding key performance indicators specific to each game mode (Time Taken for Classic, Triples Found for Arcade). Fixed a UI bug where the "PAUSED" screen would briefly appear after finishing a game. Additionally, refined the time display formatting to remove leading zeros from minutes and ensured that the text is not clipped in the layout.

---
*PR created automatically by Jules for task [10647038648239129255](https://jules.google.com/task/10647038648239129255) started by @amorris13*