### PR TITLE
Add shuffle option to rearrange cards in play

### DIFF
--- a/app/src/main/java/com/antsapps/triples/AnalyticsConstants.java
+++ b/app/src/main/java/com/antsapps/triples/AnalyticsConstants.java
@@ -21,6 +21,7 @@ public class AnalyticsConstants {
     public static final String PAUSE_GAME = "pause_game";
     public static final String RESUME_GAME = "resume_game";
     public static final String USE_HINT = "use_hint";
+    public static final String SHUFFLE_CARDS = "shuffle_cards";
     public static final String SIGN_IN = "sign_in";
     public static final String SIGN_OUT = "sign_out";
     public static final String CHANGE_SETTING = "change_setting";

--- a/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
+++ b/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
@@ -118,6 +118,7 @@ public abstract class BaseGameActivity extends BaseTriplesActivity
     super.onPrepareOptionsMenu(menu);
     menu.findItem(R.id.pause).setVisible(mGameState == GameState.ACTIVE);
     menu.findItem(R.id.play).setVisible(mGameState == GameState.PAUSED);
+    menu.findItem(R.id.shuffle).setVisible(mGameState == GameState.ACTIVE);
 
     SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(this);
     boolean hideHint = sharedPref.getBoolean(getString(R.string.pref_hide_hint), false);
@@ -139,6 +140,10 @@ public abstract class BaseGameActivity extends BaseTriplesActivity
     int itemId = item.getItemId();
     if (itemId == R.id.hint) {
       handleHintSelection();
+      return true;
+    } else if (itemId == R.id.shuffle) {
+      getGame().shuffleCardsInPlay();
+      logGameEvent(AnalyticsConstants.Event.SHUFFLE_CARDS);
       return true;
     } else if (itemId == R.id.pause) {
       getGame().pause();

--- a/app/src/main/java/com/antsapps/triples/backend/Game.java
+++ b/app/src/main/java/com/antsapps/triples/backend/Game.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Sets;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -169,6 +170,11 @@ public abstract class Game implements Comparable<Game>, OnValidTripleSelectedLis
     mGameState = GameState.ACTIVE;
     updateTimer();
     dispatchGameStateUpdate();
+  }
+
+  public void shuffleCardsInPlay() {
+    Collections.shuffle(mCardsInPlay);
+    dispatchCardsInPlayUpdate(ImmutableList.copyOf(mCardsInPlay));
   }
 
   public void resumeFromLifecycle() {

--- a/app/src/main/res/drawable/ic_shuffle.xml
+++ b/app/src/main/res/drawable/ic_shuffle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M10.59,9.17L5.41,4L4,5.41l5.17,5.17L10.59,9.17zM14.5,4l2.04,2.04L4,18.59L5.41,20L17.96,7.46L20,9.5V4H14.5zM14.83,13.41l-1.41,1.41l3.13,3.13L14.5,20H20v-5.5l-2.04,2.04L14.83,13.41z"/>
+</vector>

--- a/app/src/main/res/menu/game.xml
+++ b/app/src/main/res/menu/game.xml
@@ -8,6 +8,11 @@
       app:showAsAction="always"
       android:title="@string/hint" />
   <item
+      android:id="@+id/shuffle"
+      android:icon="@drawable/ic_shuffle"
+      app:showAsAction="ifRoom"
+      android:title="@string/shuffle" />
+  <item
       android:id="@+id/pause"
       android:icon="@drawable/ic_pause"
       app:showAsAction="always"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,7 +74,8 @@
   <string name="zen_label">Zen</string>
   <string name="beginner_label">Beginner</string>
   <string name="game_completed">GAME COMPLETED</string>
-    <string name="hint">Hint</string>
+  <string name="hint">Hint</string>
+  <string name="shuffle">Shuffle</string>
     <string name="fastest_triple">Fastest triple:</string>
     <string name="slowest_triple">Slowest triple:</string>
     <string name="time_taken_field">Time taken:</string>

--- a/app/src/test/java/com/antsapps/triples/backend/GameTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/GameTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
@@ -89,5 +91,40 @@ public class GameTest {
 
     List<Integer> positions = Game.getValidTriplePositions(cards);
     assertThat(positions).containsExactly(0, 2, 3);
+  }
+
+  @Test
+  public void shuffleCardsInPlay_rearrangesCards() {
+    Card c1 = new Card(0, 0, 0, 0);
+    Card c2 = new Card(1, 1, 1, 1);
+    Card c3 = new Card(2, 2, 2, 2);
+    Card c4 = new Card(0, 0, 0, 1);
+    List<Card> cardsInPlay = ImmutableList.of(c1, c2, c3, c4);
+
+    Game game = new Game(0, 0, cardsInPlay, Collections.emptyList(), new Deck(Collections.emptyList()), 0, new Date(), Game.GameState.ACTIVE, false) {
+      @Override
+      protected boolean isGameInValidState() {
+        return true;
+      }
+      @Override
+      public String getGameTypeForAnalytics() {
+        return "Test";
+      }
+    };
+    game.setGameRenderer(new Game.GameRenderer() {
+      @Override
+      public void updateCardsInPlay(ImmutableList<Card> newCards) {}
+      @Override
+      public void addHint(Card card) {}
+      @Override
+      public void clearHintedCards() {}
+      @Override
+      public Set<Card> getSelectedCards() { return Collections.emptySet(); }
+    });
+
+    // We can't guarantee a shuffle will change order with only 4 cards, but it usually does.
+    // To be more robust, we check that it still contains the same cards.
+    game.shuffleCardsInPlay();
+    assertThat(game.getCardsInPlay()).containsExactly(c1, c2, c3, c4);
   }
 }


### PR DESCRIPTION
Implemented a "Shuffle" feature that allows players to rearrange the cards currently on the screen. This is useful when a player is stuck and wants a fresh perspective on the layout. The shuffle operation only affects the cards currently in play and does not modify the remaining cards in the deck.

Key changes:
- Created `ic_shuffle.xml` vector drawable and added a "Shuffle" string resource.
- Added a shuffle menu item to `app/src/main/res/menu/game.xml`.
- Implemented `shuffleCardsInPlay()` in `Game.java` to shuffle the `mCardsInPlay` list and notify the UI.
- Updated `BaseGameActivity.java` to handle the shuffle menu item and manage its visibility based on the game state.
- Added `SHUFFLE_CARDS` event to `AnalyticsConstants.java` for tracking usage.
- Added a unit test in `GameTest.java` to ensure the shuffle logic correctly preserves the set of cards in play.

---
*PR created automatically by Jules for task [15681364576373671462](https://jules.google.com/task/15681364576373671462) started by @amorris13*