### PR TITLE
Define Daily puzzle mode accent colors for dark mode

### DIFF
--- a/app/src/main/java/com/antsapps/triples/DailyStatisticsFragment.java
+++ b/app/src/main/java/com/antsapps/triples/DailyStatisticsFragment.java
@@ -15,6 +15,7 @@ import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import com.antsapps.triples.backend.Application;
 import com.antsapps.triples.backend.DailyGame;
@@ -192,6 +193,8 @@ public class DailyStatisticsFragment extends Fragment {
 
   private static class CalendarAdapter extends BaseAdapter {
     private final Context mContext;
+    private final int mTextPrimaryColor;
+    private final int mTextSecondaryColor;
     private final List<Calendar> mDays;
     private final Set<Long> mCompletedOnDaySeeds;
     private final Set<Long> mCompletedLateSeeds;
@@ -200,6 +203,8 @@ public class DailyStatisticsFragment extends Fragment {
 
     CalendarAdapter(Context context, Calendar month, List<DailyGame> completedGames) {
       mContext = context;
+      mTextPrimaryColor = ContextCompat.getColor(mContext, R.color.color_text_primary);
+      mTextSecondaryColor = ContextCompat.getColor(mContext, R.color.color_text_secondary);
       mMonth = month.get(Calendar.MONTH);
       mTodaySeed = getStartOfDay(System.currentTimeMillis());
 
@@ -243,7 +248,7 @@ public class DailyStatisticsFragment extends Fragment {
             {
                 mPaint.setStyle(Paint.Style.STROKE);
                 mPaint.setStrokeWidth(2);
-                mPaint.setColor(Color.BLACK);
+                mPaint.setColor(mTextPrimaryColor);
             }
             @Override
             protected void onDraw(Canvas canvas) {
@@ -265,17 +270,17 @@ public class DailyStatisticsFragment extends Fragment {
       long daySeed = getStartOfDay(day.getTimeInMillis());
 
       if (day.get(Calendar.MONTH) != mMonth) {
-        tv.setTextColor(Color.LTGRAY);
-        tv.setBackgroundColor(Color.TRANSPARENT);
+        tv.setTextColor(mTextSecondaryColor);
+        tv.setBackgroundColor(android.graphics.Color.TRANSPARENT);
       } else if (daySeed > mTodaySeed) {
-        tv.setTextColor(Color.LTGRAY);
-        tv.setBackgroundColor(Color.TRANSPARENT);
+        tv.setTextColor(mTextSecondaryColor);
+        tv.setBackgroundColor(android.graphics.Color.TRANSPARENT);
       } else {
-        tv.setTextColor(Color.BLACK);
+        tv.setTextColor(mTextPrimaryColor);
         if (mCompletedOnDaySeeds.contains(daySeed)) {
-          tv.setBackgroundColor(mContext.getResources().getColor(R.color.daily_accent));
+          tv.setBackgroundColor(ContextCompat.getColor(mContext, R.color.daily_accent));
         } else if (mCompletedLateSeeds.contains(daySeed)) {
-          tv.setBackgroundColor(mContext.getResources().getColor(R.color.daily_background));
+          tv.setBackgroundColor(ContextCompat.getColor(mContext, R.color.daily_background));
         } else {
           tv.setBackgroundColor(Color.TRANSPARENT);
         }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -32,10 +32,13 @@
   <color name="arcade_background">#002d00</color>
   <color name="zen_background">#2d002d</color>
 
+  <color name="daily_background">#2D1A00</color>
+
   <!-- Dark mode accents (Material 200) -->
   <color name="classic_accent">#90CAF9</color>
   <color name="arcade_accent">#A5D6A7</color>
   <color name="zen_accent">#CE93D8</color>
+  <color name="daily_accent">#FFCC80</color>
 
   <!-- Semantic colors for dark mode support -->
   <color name="color_separator">#0097A7</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -86,7 +86,7 @@
     <item name="colorPrimary">@color/zen_accent</item>
   </style>
 
-  <style name="DailyButtonTheme" parent="ThemeOverlay.Material3.Light">
+  <style name="DailyButtonTheme" parent="ThemeOverlay.Material3">
     <item name="colorPrimary">@color/daily_accent</item>
   </style>
 

--- a/app/src/test/java/com/antsapps/triples/ColoringTest.java
+++ b/app/src/test/java/com/antsapps/triples/ColoringTest.java
@@ -14,6 +14,7 @@ import androidx.test.core.app.ApplicationProvider;
 import com.antsapps.triples.backend.Application;
 import com.antsapps.triples.backend.ClassicGame;
 import com.antsapps.triples.backend.ArcadeGame;
+import com.antsapps.triples.backend.DailyGame;
 import com.antsapps.triples.backend.Game;
 import org.junit.Test;
 
@@ -67,6 +68,42 @@ public class ColoringTest extends BaseRobolectricTest {
         int expectedColor = ContextCompat.getColor(ApplicationProvider.getApplicationContext(), R.color.arcade_accent);
 
         try (ActivityScenario<ArcadeGameActivity> scenario = ActivityScenario.launch(intent)) {
+            scenario.onActivity(activity -> {
+                // Check Action Bar Title is not colored
+                CharSequence title = activity.getTitle();
+                if (title instanceof SpannableString) {
+                    SpannableString ss = (SpannableString) title;
+                    ForegroundColorSpan[] spans = ss.getSpans(0, ss.length(), ForegroundColorSpan.class);
+                    assertThat(spans).isEmpty();
+                }
+
+                // Check bottom separator color
+                View bottomSeparator = activity.findViewById(R.id.bottom_separator);
+                assertThat(((ColorDrawable) bottomSeparator.getBackground()).getColor()).isEqualTo(expectedColor);
+
+                // Check paused text color
+                TextView pausedText = activity.findViewById(R.id.paused);
+                assertThat(pausedText.getCurrentTextColor()).isEqualTo(expectedColor);
+
+                // Check button tints
+                assertThat(activity.findViewById(R.id.statistics_button).getBackgroundTintList()).isEqualTo(ColorStateList.valueOf(expectedColor));
+                assertThat(activity.findViewById(R.id.new_game_button).getBackgroundTintList()).isEqualTo(ColorStateList.valueOf(expectedColor));
+            });
+        }
+    }
+
+    @Test
+    public void testDailyGameColoring() {
+        Application app = Application.getInstance(ApplicationProvider.getApplicationContext());
+        DailyGame game = DailyGame.createFromSeed(12345L);
+        app.addDailyGame(game);
+
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(), DailyGameActivity.class);
+        intent.putExtra(Game.ID_TAG, game.getId());
+
+        int expectedColor = ContextCompat.getColor(ApplicationProvider.getApplicationContext(), R.color.daily_accent);
+
+        try (ActivityScenario<DailyGameActivity> scenario = ActivityScenario.launch(intent)) {
             scenario.onActivity(activity -> {
                 // Check Action Bar Title is not colored
                 CharSequence title = activity.getTitle();

--- a/app/src/test/java/com/antsapps/triples/backend/GameTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/GameTest.java
@@ -119,6 +119,8 @@ public class GameTest {
       @Override
       public void clearHintedCards() {}
       @Override
+      public void clearSelectedCards() {}
+      @Override
       public Set<Card> getSelectedCards() { return Collections.emptySet(); }
     });
 


### PR DESCRIPTION
This change defines the accent and background colors for the Daily Puzzle mode in both light and dark themes. It also updates the DailyStatisticsFragment to use these colors along with theme-aware semantic text colors, ensuring visibility in dark mode. Additionally, it updates the DailyButtonTheme and adds a unit test to verify the correct application of the daily accent color.

---
*PR created automatically by Jules for task [2379597797396620005](https://jules.google.com/task/2379597797396620005) started by @amorris13*