### PR TITLE
Add visual feedback for disabled calendar navigation buttons in Daily Stats

### DIFF
--- a/app/src/main/res/color/selector_month_nav.xml
+++ b/app/src/main/res/color/selector_month_nav.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="?attr/colorOnSurfaceVariant" android:state_enabled="false" />
+  <item android:color="?attr/colorOnSurface" />
+</selector>

--- a/app/src/main/res/layout/daily_stats_fragment.xml
+++ b/app/src/main/res/layout/daily_stats_fragment.xml
@@ -94,7 +94,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="&lt;"
-            android:textColor="?attr/colorOnSurface" />
+            android:textColor="@color/selector_month_nav" />
 
         <Button
             android:id="@+id/month_title"
@@ -105,7 +105,7 @@
             android:gravity="center"
             android:textSize="18sp"
             android:textStyle="bold"
-            android:textColor="?attr/colorOnSurface" />
+            android:textColor="@color/selector_month_nav" />
 
         <Button
             android:id="@+id/next_month"
@@ -113,7 +113,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="&gt;"
-            android:textColor="?attr/colorOnSurface" />
+            android:textColor="@color/selector_month_nav" />
     </LinearLayout>
 
     <LinearLayout


### PR DESCRIPTION
The Daily Statistics calendar navigation buttons (Next, Previous, Month Title) previously did not change appearance when disabled, making it unclear to the user that they were not clickable.

I created a new color selector `selector_month_nav.xml` in `app/src/main/res/color/` that uses Material 3 theme attributes to differentiate between the enabled and disabled states. This selector was then applied to the navigation buttons in `daily_stats_fragment.xml`.

Verified that the layout XML is correctly updated and that the project still builds and passes tests.

---
*PR created automatically by Jules for task [15722803219464796432](https://jules.google.com/task/15722803219464796432) started by @amorris13*