### PR TITLE
Center pulse animation in FoundTriplesView

### DIFF
--- a/app/src/main/java/com/antsapps/triples/views/FoundTriplesView.java
+++ b/app/src/main/java/com/antsapps/triples/views/FoundTriplesView.java
@@ -109,6 +109,8 @@ public class FoundTriplesView extends View {
     int naturalHeight = existingBounds.height();
     int naturalDisplacement = (int) (naturalHeight * STACK_DISPLACEMENT_PERCENT);
     float scale = (float) mCardWidth / naturalWidth;
+    float centerX = naturalWidth / 2f;
+    float centerY = (naturalHeight + 2 * naturalDisplacement) / 2f;
 
     for (int i = 0; i < mTotalTriples; i++) {
       int row = i / COLUMNS;
@@ -119,8 +121,10 @@ public class FoundTriplesView extends View {
 
       canvas.save();
       canvas.translate(left, top);
-      float highlightScale = (i == mHighlightIndex) ? mHighlightScale : 1.0f;
-      canvas.scale(scale * highlightScale, scale * highlightScale, 0, 0);
+      canvas.scale(scale, scale);
+      if (i == mHighlightIndex) {
+        canvas.scale(mHighlightScale, mHighlightScale, centerX, centerY);
+      }
 
       if (mFoundTriples != null && i < mFoundTriples.size()) {
         drawTripleStack(


### PR DESCRIPTION
Modified the `onDraw` method in `FoundTriplesView.java` to:
1. Calculate the center of the triple stack in "natural" (unscaled) coordinates.
2. Separate the base scaling (used to fit the stack into its grid slot) from the highlight pulsing scaling.
3. Apply the highlight scaling using the calculated center as the pivot point.

This change provides a more visually appealing pulsing effect when a previously found triple is selected again.

---
*PR created automatically by Jules for task [15560027974234127728](https://jules.google.com/task/15560027974234127728) started by @amorris13*