### PR TITLE
Display progress sector for partially complete Daily Puzzles on calendar

### DIFF
--- a/app/src/main/java/com/antsapps/triples/DailyStatisticsFragment.java
+++ b/app/src/main/java/com/antsapps/triples/DailyStatisticsFragment.java
@@ -303,7 +303,6 @@ public class DailyStatisticsFragment extends Fragment implements CsvExportable {
       mHintDates = new HashSet<>();
       mProgressMap = new HashMap<>();
       for (DailyGame game : allGames) {
-        if (game.getDateCompleted() == null) continue;
         DailyGame.Day day = game.getGameDay();
         if (game.areHintsUsed()) {
           mHintDates.add(day);
@@ -315,7 +314,8 @@ public class DailyStatisticsFragment extends Fragment implements CsvExportable {
             mCompletedLateDates.add(day);
           }
         } else if (game.getNumTriplesFound() > 0) {
-          mProgressMap.put(day, (float) game.getNumTriplesFound() / game.getTotalTriplesCount());
+          mProgressMap.put(
+              day, (float) game.getNumTriplesFound() / (float) game.getTotalTriplesCount());
         }
       }
     }
@@ -381,16 +381,14 @@ public class DailyStatisticsFragment extends Fragment implements CsvExportable {
                 } else if (mCompletedLateDates.contains(day)) {
                   mPaint.setStyle(Paint.Style.FILL);
                   int color = ContextCompat.getColor(mContext, R.color.daily_accent);
-                  mPaint.setColor(
-                      Color.argb(128, Color.red(color), Color.green(color), Color.blue(color)));
+                  mPaint.setColor(updateAlpha(color, 128));
                   canvas.drawCircle(centerX, centerY, radius, mPaint);
                 } else if (mProgressMap.containsKey(day)) {
                   float progress = mProgressMap.get(day);
                   mPaint.setStyle(Paint.Style.FILL);
                   int color = ContextCompat.getColor(mContext, R.color.daily_accent);
                   if (!day.equals(mToday)) {
-                    color =
-                        Color.argb(128, Color.red(color), Color.green(color), Color.blue(color));
+                    color = updateAlpha(color, 128);
                   }
                   mPaint.setColor(color);
                   RectF rectF =
@@ -445,6 +443,10 @@ public class DailyStatisticsFragment extends Fragment implements CsvExportable {
       }
 
       return tv;
+    }
+
+    private static int updateAlpha(int color, int alpha) {
+      return Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color));
     }
   }
 }


### PR DESCRIPTION
The Daily Puzzle calendar now provides visual feedback for partially completed puzzles. Instead of only showing a solid circle for completed puzzles, it now displays a circular sector (pie slice) that corresponds to the percentage of triples found for puzzles that are still in progress.

Key changes:
- `DailyStatisticsFragment.java`:
    - Updated `CalendarAdapter` to process all daily games from the application.
    - Added a `mProgressMap` to store the progress ratio of incomplete games.
    - Modified the custom `TextView.onDraw` to render the progress sector using `canvas.drawArc`.
    - Added logic to ensure hints are marked correctly for both complete and incomplete games.
- Verified that all unit tests pass.

---
*PR created automatically by Jules for task [6693854561337212148](https://jules.google.com/task/6693854561337212148) started by @amorris13*