### PR TITLE
Add unit tests for DailyStatisticsUtil

### DIFF
--- a/app/src/test/java/com/antsapps/triples/backend/DailyStatisticsUtilTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/DailyStatisticsUtilTest.java
@@ -1,26 +1,57 @@
 package com.antsapps.triples.backend;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.antsapps.triples.BaseRobolectricTest;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import org.junit.Test;
 
 public class DailyStatisticsUtilTest extends BaseRobolectricTest {
 
-  private DailyGame mockGame(
+  private DailyGame createGame(
       DailyGame.Day day, boolean completed, boolean hintsUsed, boolean completedOnTime) {
-    DailyGame game = mock(DailyGame.class);
-    when(game.getGameDay()).thenReturn(day);
-    when(game.getDateCompleted()).thenReturn(completed ? new Date() : null);
-    when(game.areHintsUsed()).thenReturn(hintsUsed);
-    when(game.isCompletedOnTime()).thenReturn(completedOnTime);
-    return game;
+    Date dateCompleted = null;
+    if (completed) {
+      if (completedOnTime) {
+        dateCompleted = day.getCalendar().getTime();
+      } else {
+        // More than 48 hours after the start of the day
+        dateCompleted =
+            new Date(day.getCalendar().getTimeInMillis() + DailyGame.STREAK_BUFFER_MILLIS + 1000);
+      }
+    }
+
+    // DailyGame constructor calls Game.getAllValidTriples(mCardsInPlay)
+    // which calls Sets.combinations(mCardsInPlay, 3).
+    // So we must provide at least 3 cards to avoid IllegalArgumentException.
+    List<Card> cards = new ArrayList<>();
+    cards.add(new Card(0, 0, 0, 0));
+    cards.add(new Card(1, 1, 1, 1));
+    cards.add(new Card(2, 2, 2, 2));
+
+    return new DailyGame(
+        -1,
+        day.getSeed(),
+        cards,
+        Collections.<Long>emptyList(),
+        new Deck(Collections.<Card>emptyList()),
+        0,
+        new Date(),
+        day,
+        completed ? Game.GameState.COMPLETED : Game.GameState.ACTIVE,
+        hintsUsed,
+        Collections.<Set<Card>>emptyList(),
+        dateCompleted) {
+      @Override
+      protected void init() {
+        // override to avoid potential issues if it's called
+      }
+    };
   }
 
   @Test
@@ -38,9 +69,9 @@ public class DailyStatisticsUtilTest extends BaseRobolectricTest {
     DailyGame.Day day1 = new DailyGame.Day(2024, 1, 1);
     DailyGame.Day day2 = new DailyGame.Day(2024, 1, 2);
     DailyGame.Day day3 = new DailyGame.Day(2024, 1, 3);
-    games.add(mockGame(day1, true, false, true)); // Solved, no hints
-    games.add(mockGame(day2, true, true, true)); // Solved, but hints used
-    games.add(mockGame(day3, false, false, false)); // Not solved
+    games.add(createGame(day1, true, false, true)); // Solved, no hints
+    games.add(createGame(day2, true, true, true)); // Solved, but hints used
+    games.add(createGame(day3, false, false, false)); // Not solved
 
     DailyStatisticsUtil.DailyStatistics stats = DailyStatisticsUtil.computeDailyStatistics(games);
     assertThat(stats.totalGamesCompleted).isEqualTo(1);
@@ -54,8 +85,8 @@ public class DailyStatisticsUtilTest extends BaseRobolectricTest {
     DailyGame.Day yesterday = DailyGame.Day.forCalendar(cal);
 
     List<DailyGame> games = new ArrayList<>();
-    games.add(mockGame(today, true, false, true));
-    games.add(mockGame(yesterday, true, false, true));
+    games.add(createGame(today, true, false, true));
+    games.add(createGame(yesterday, true, false, true));
 
     DailyStatisticsUtil.DailyStatistics stats = DailyStatisticsUtil.computeDailyStatistics(games);
     assertThat(stats.currentStreak).isEqualTo(2);
@@ -71,8 +102,8 @@ public class DailyStatisticsUtilTest extends BaseRobolectricTest {
     DailyGame.Day dayBefore = DailyGame.Day.forCalendar(cal);
 
     List<DailyGame> games = new ArrayList<>();
-    games.add(mockGame(yesterday, true, false, true));
-    games.add(mockGame(dayBefore, true, false, true));
+    games.add(createGame(yesterday, true, false, true));
+    games.add(createGame(dayBefore, true, false, true));
 
     DailyStatisticsUtil.DailyStatistics stats = DailyStatisticsUtil.computeDailyStatistics(games);
     assertThat(stats.currentStreak).isEqualTo(2);
@@ -87,7 +118,7 @@ public class DailyStatisticsUtilTest extends BaseRobolectricTest {
     DailyGame.Day dayBeforeYesterday = DailyGame.Day.forCalendar(cal);
 
     List<DailyGame> games = new ArrayList<>();
-    games.add(mockGame(dayBeforeYesterday, true, false, true));
+    games.add(createGame(dayBeforeYesterday, true, false, true));
 
     DailyStatisticsUtil.DailyStatistics stats = DailyStatisticsUtil.computeDailyStatistics(games);
     assertThat(stats.currentStreak).isEqualTo(0);
@@ -96,13 +127,13 @@ public class DailyStatisticsUtilTest extends BaseRobolectricTest {
   @Test
   public void testLongestStreak() {
     List<DailyGame> games = new ArrayList<>();
-    games.add(mockGame(new DailyGame.Day(2024, 1, 1), true, false, true));
-    games.add(mockGame(new DailyGame.Day(2024, 1, 2), true, false, true));
-    games.add(mockGame(new DailyGame.Day(2024, 1, 3), true, false, true));
+    games.add(createGame(new DailyGame.Day(2024, 1, 1), true, false, true));
+    games.add(createGame(new DailyGame.Day(2024, 1, 2), true, false, true));
+    games.add(createGame(new DailyGame.Day(2024, 1, 3), true, false, true));
 
     // Gap
-    games.add(mockGame(new DailyGame.Day(2024, 1, 5), true, false, true));
-    games.add(mockGame(new DailyGame.Day(2024, 1, 6), true, false, true));
+    games.add(createGame(new DailyGame.Day(2024, 1, 5), true, false, true));
+    games.add(createGame(new DailyGame.Day(2024, 1, 6), true, false, true));
 
     DailyStatisticsUtil.DailyStatistics stats = DailyStatisticsUtil.computeDailyStatistics(games);
     assertThat(stats.longestStreak).isEqualTo(3);
@@ -111,8 +142,8 @@ public class DailyStatisticsUtilTest extends BaseRobolectricTest {
   @Test
   public void testLongestStreak_YearBoundary() {
     List<DailyGame> games = new ArrayList<>();
-    games.add(mockGame(new DailyGame.Day(2023, 12, 31), true, false, true));
-    games.add(mockGame(new DailyGame.Day(2024, 1, 1), true, false, true));
+    games.add(createGame(new DailyGame.Day(2023, 12, 31), true, false, true));
+    games.add(createGame(new DailyGame.Day(2024, 1, 1), true, false, true));
 
     DailyStatisticsUtil.DailyStatistics stats = DailyStatisticsUtil.computeDailyStatistics(games);
     assertThat(stats.longestStreak).isEqualTo(2);


### PR DESCRIPTION
Added unit tests for DailyStatisticsUtil to ensure accurate calculation of game statistics and streaks.
The tests verify total games completed, current streak logic (including handling of 'today' and 'yesterday'), and longest streak logic (including year boundaries).

---
*PR created automatically by Jules for task [1656454896180874402](https://jules.google.com/task/1656454896180874402) started by @amorris13*