### PR TITLE
Increase card symbol stroke width

### DIFF
--- a/app/src/main/java/com/antsapps/triples/cardsview/SymbolDrawable.java
+++ b/app/src/main/java/com/antsapps/triples/cardsview/SymbolDrawable.java
@@ -20,7 +20,7 @@ import com.antsapps.triples.backend.Card;
 
 public class SymbolDrawable extends Drawable {
 
-  public static final int OUTLINE_WIDTH = 2;
+  public static final int OUTLINE_WIDTH = 3;
 
   private final Card mCard;
 


### PR DESCRIPTION
Increased the stroke width of card symbols by updating the `OUTLINE_WIDTH` constant in `SymbolDrawable.java`. This provides better visibility and a more prominent look for the shapes on the cards. Verified the change by inspecting the code and running existing unit tests.

---
*PR created automatically by Jules for task [7529959289628568783](https://jules.google.com/task/7529959289628568783) started by @amorris13*