### PR TITLE
Use discrete steps for animation duration setting with Material Slider

### DIFF
--- a/app/src/main/java/com/antsapps/triples/MaterialSliderPreference.java
+++ b/app/src/main/java/com/antsapps/triples/MaterialSliderPreference.java
@@ -1,0 +1,85 @@
+package com.antsapps.triples;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+import com.google.android.material.slider.Slider;
+
+public class MaterialSliderPreference extends Preference {
+
+  private float valueFrom = 0f;
+  private float valueTo = 100f;
+  private float stepSize = 1f;
+  private int value;
+
+  public MaterialSliderPreference(@NonNull Context context, @Nullable AttributeSet attrs) {
+    super(context, attrs);
+    setLayoutResource(R.layout.preference_material_slider);
+
+    TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.MaterialSliderPreference);
+    valueFrom = a.getFloat(R.styleable.MaterialSliderPreference_valueFrom, 0f);
+    valueTo = a.getFloat(R.styleable.MaterialSliderPreference_valueTo, 100f);
+    stepSize = a.getFloat(R.styleable.MaterialSliderPreference_stepSize, 1f);
+    a.recycle();
+  }
+
+  @Override
+  public void onBindViewHolder(@NonNull PreferenceViewHolder holder) {
+    super.onBindViewHolder(holder);
+    Slider slider = (Slider) holder.findViewById(R.id.slider);
+    slider.clearOnChangeListeners();
+    slider.setValueFrom(valueFrom);
+    slider.setValueTo(valueTo);
+    slider.setStepSize(stepSize);
+    slider.setValue(value);
+    slider.setEnabled(isEnabled());
+    slider.addOnChangeListener(
+        (s, v, fromUser) -> {
+          if (fromUser) {
+            int newValue = (int) v;
+            if (callChangeListener(newValue)) {
+              setValue(newValue);
+            }
+          }
+        });
+  }
+
+  @Override
+  protected Object onGetDefaultValue(TypedArray a, int index) {
+    return a.getInt(index, 0);
+  }
+
+  @Override
+  protected void onSetInitialValue(Object defaultValue) {
+    int initialValue;
+    if (defaultValue instanceof Integer) {
+      initialValue = (Integer) defaultValue;
+    } else {
+      initialValue = getPersistedInt(0);
+    }
+    setValue(roundToStep(initialValue));
+  }
+
+  public void setValue(int newValue) {
+    int roundedValue = roundToStep(newValue);
+    if (value != roundedValue) {
+      value = roundedValue;
+      persistInt(roundedValue);
+      notifyChanged();
+    }
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  private int roundToStep(int val) {
+    if (stepSize == 0) return val;
+    float stepped = Math.round((val - valueFrom) / stepSize) * stepSize + valueFrom;
+    return (int) Math.max(valueFrom, Math.min(valueTo, stepped));
+  }
+}

--- a/app/src/main/java/com/antsapps/triples/SettingsFragment.java
+++ b/app/src/main/java/com/antsapps/triples/SettingsFragment.java
@@ -9,7 +9,6 @@ import androidx.core.content.ContextCompat;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceGroup;
-import androidx.preference.SeekBarPreference;
 import com.antsapps.triples.backend.Application;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.firebase.analytics.FirebaseAnalytics;
@@ -27,7 +26,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
     setupListeners(getPreferenceScreen());
 
-    SeekBarPreference animationDurationPref =
+    MaterialSliderPreference animationDurationPref =
         findPreference(getString(R.string.pref_animation_speed));
     if (animationDurationPref != null) {
       animationDurationPref.setSummary(

--- a/app/src/main/res/layout/preference_material_slider.xml
+++ b/app/src/main/res/layout/preference_material_slider.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:orientation="vertical"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    android:clipChildren="false"
+    android:clipToPadding="false">
+
+    <TextView
+        android:id="@android:id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceListItem"
+        android:textColor="?android:attr/textColorPrimary" />
+
+    <TextView
+        android:id="@android:id/summary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:maxLines="10" />
+
+    <com.google.android.material.slider.Slider
+        android:id="@+id/slider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:stepSize="1.0"
+        android:valueFrom="0.0"
+        android:valueTo="100.0" />
+
+</LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="MaterialSliderPreference">
+        <attr name="valueFrom" format="float" />
+        <attr name="valueTo" format="float" />
+        <attr name="stepSize" format="float" />
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -24,15 +24,12 @@
       android:title="Theme"
       android:summary="%s" />
 
-  <androidx.preference.SeekBarPreference
+  <com.antsapps.triples.MaterialSliderPreference
       android:defaultValue="800"
       android:key="@string/pref_animation_speed"
-      android:min="0"
-      android:max="1000"
-      app:seekBarIncrement="100"
-      app:adjustable="true"
-      app:showSeekBarValue="false"
-      app:updatesContinuously="true"
+      app:valueFrom="0"
+      app:valueTo="1000"
+      app:stepSize="100"
       android:title="@string/pref_animation_duration_title"/>
 
   <androidx.preference.PreferenceCategory

--- a/app/src/test/java/com/antsapps/triples/AnimationDurationSummaryTest.java
+++ b/app/src/test/java/com/antsapps/triples/AnimationDurationSummaryTest.java
@@ -2,7 +2,6 @@ package com.antsapps.triples;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import androidx.preference.SeekBarPreference;
 import androidx.test.core.app.ActivityScenario;
 import org.junit.Test;
 
@@ -17,7 +16,7 @@ public class AnimationDurationSummaryTest extends BaseRobolectricTest {
             SettingsFragment fragment =
                 (SettingsFragment)
                     activity.getSupportFragmentManager().findFragmentByTag(".SettingsFragment");
-            SeekBarPreference animationDurationPref =
+            MaterialSliderPreference animationDurationPref =
                 fragment.findPreference(activity.getString(R.string.pref_animation_speed));
 
             assertThat(animationDurationPref).isNotNull();


### PR DESCRIPTION
I have updated the animation duration setting to use a Material Slider with discrete 100ms steps, ranging from 0 to 1000ms. I also implemented logic to round existing preference values to the nearest 100ms to ensure a smooth transition. Unit tests were updated and passed successfully.

---
*PR created automatically by Jules for task [6570703340423027052](https://jules.google.com/task/6570703340423027052) started by @amorris13*