### PR TITLE
Add "Include hinted" toggle to Classic and Arcade statistics

### DIFF
--- a/app/src/main/java/com/antsapps/triples/backend/ArcadeStatistics.java
+++ b/app/src/main/java/com/antsapps/triples/backend/ArcadeStatistics.java
@@ -21,9 +21,6 @@ public class ArcadeStatistics extends Statistics {
     long leastDate = 0;
 
     for (Game game : mGamesInPeriod) {
-      if (game.areHintsUsed()) {
-        continue;
-      }
       ArcadeGame arcadeGame = (ArcadeGame) game;
       long found = arcadeGame.getNumTriplesFound();
       long date = arcadeGame.getDateStarted().getTime();
@@ -40,16 +37,11 @@ public class ArcadeStatistics extends Statistics {
       }
     }
 
-    int numGamesNotHinted = 0;
-    for (Game game : mGamesInPeriod) {
-      if (!game.areHintsUsed()) {
-        numGamesNotHinted++;
-      }
-    }
+    int numGames = mGamesInPeriod.size();
 
     mMostFound = mostFound;
     mLeastFound = leastFound;
-    mAverageFound = numGamesNotHinted != 0 ? sumFound / numGamesNotHinted : 0;
+    mAverageFound = numGames != 0 ? sumFound / numGames : 0;
     mMostFoundDate = mostDate;
     mLeastFoundDate = leastDate;
   }

--- a/app/src/main/java/com/antsapps/triples/backend/ClassicStatistics.java
+++ b/app/src/main/java/com/antsapps/triples/backend/ClassicStatistics.java
@@ -25,9 +25,6 @@ public class ClassicStatistics extends Statistics {
     long slowDate = 0;
 
     for (Game game : mGamesInPeriod) {
-      if (game.areHintsUsed()) {
-        continue;
-      }
       long time = game.getTimeElapsed();
       long date = game.getDateStarted().getTime();
 
@@ -50,16 +47,11 @@ public class ClassicStatistics extends Statistics {
       }
     }
 
-    int numGamesNotHinted = 0;
-    for (Game game : mGamesInPeriod) {
-      if (!game.areHintsUsed()) {
-        numGamesNotHinted++;
-      }
-    }
+    int numGames = mGamesInPeriod.size();
 
     mFastTime = fastTime;
     mSlowTime = slowTime;
-    mAverageTime = numGamesNotHinted != 0 ? sumTime / numGamesNotHinted : 0;
+    mAverageTime = numGames != 0 ? sumTime / numGames : 0;
     mStartDate = startDate;
     mFinishDate = finishDate;
     mFastDate = fastDate;

--- a/app/src/main/java/com/antsapps/triples/stats/ArcadeStatisticsFragment.java
+++ b/app/src/main/java/com/antsapps/triples/stats/ArcadeStatisticsFragment.java
@@ -52,6 +52,11 @@ public class ArcadeStatisticsFragment extends BaseStatisticsFragment {
   }
 
   @Override
+  public void onIncludeHintedChange(boolean includeHinted) {
+    mViewModel.setIncludeHinted(includeHinted);
+  }
+
+  @Override
   protected ArrayAdapter<Game> createArrayAdapter() {
     return new StatisticsGamesArrayAdapter(getActivity(), Lists.<Game>newArrayList());
   }

--- a/app/src/main/java/com/antsapps/triples/stats/ArcadeStatisticsViewModel.java
+++ b/app/src/main/java/com/antsapps/triples/stats/ArcadeStatisticsViewModel.java
@@ -11,6 +11,7 @@ import com.antsapps.triples.backend.Period;
 public class ArcadeStatisticsViewModel extends ViewModel {
   private final MediatorLiveData<ArcadeStatistics> mStatistics = new MediatorLiveData<>();
   private final MutableLiveData<Period> mPeriod = new MutableLiveData<>(Period.ALL_TIME);
+  private final MutableLiveData<Boolean> mIncludeHinted = new MutableLiveData<>(false);
 
   private boolean mInitialized = false;
 
@@ -22,10 +23,12 @@ public class ArcadeStatisticsViewModel extends ViewModel {
 
     mStatistics.addSource(application.getArcadeGamesLiveData(), games -> update(application));
     mStatistics.addSource(mPeriod, period -> update(application));
+    mStatistics.addSource(mIncludeHinted, includeHinted -> update(application));
   }
 
   private void update(Application application) {
-    mStatistics.setValue(application.getArcadeStatistics(mPeriod.getValue(), false));
+    mStatistics.setValue(
+        application.getArcadeStatistics(mPeriod.getValue(), mIncludeHinted.getValue()));
   }
 
   public LiveData<ArcadeStatistics> getStatistics() {
@@ -34,5 +37,9 @@ public class ArcadeStatisticsViewModel extends ViewModel {
 
   public void setPeriod(Period period) {
     mPeriod.setValue(period);
+  }
+
+  public void setIncludeHinted(boolean includeHinted) {
+    mIncludeHinted.setValue(includeHinted);
   }
 }

--- a/app/src/main/java/com/antsapps/triples/stats/BaseStatisticsFragment.java
+++ b/app/src/main/java/com/antsapps/triples/stats/BaseStatisticsFragment.java
@@ -22,6 +22,7 @@ public abstract class BaseStatisticsFragment extends BaseGameListFragment
     implements OnStatisticsChangeListener,
         OnComparatorChangeListener<Game>,
         StatisticsSelectorView.OnPeriodChangeListener,
+        StatisticsSelectorView.OnIncludeHintedChangeListener,
         CsvExportable {
   private BaseTriplesActivity mGameListActivity;
   private Comparator<Game> mComparator = GameProperty.TIME_ELAPSED.createReversableComparator();
@@ -50,6 +51,7 @@ public abstract class BaseStatisticsFragment extends BaseGameListFragment
 
     mSelectorView = new StatisticsSelectorView(getActivity());
     mSelectorView.setOnPeriodChangeListener(this);
+    mSelectorView.setOnIncludeHintedChangeListener(this);
     listView.addHeaderView(mSelectorView, null, false);
 
     int accentColor = getAccentColor();

--- a/app/src/main/java/com/antsapps/triples/stats/ClassicStatisticsFragment.java
+++ b/app/src/main/java/com/antsapps/triples/stats/ClassicStatisticsFragment.java
@@ -54,6 +54,11 @@ public class ClassicStatisticsFragment extends BaseStatisticsFragment {
   }
 
   @Override
+  public void onIncludeHintedChange(boolean includeHinted) {
+    mViewModel.setIncludeHinted(includeHinted);
+  }
+
+  @Override
   protected ArrayAdapter<Game> createArrayAdapter() {
     return new StatisticsGamesArrayAdapter(getActivity(), Lists.<Game>newArrayList());
   }

--- a/app/src/main/java/com/antsapps/triples/stats/ClassicStatisticsViewModel.java
+++ b/app/src/main/java/com/antsapps/triples/stats/ClassicStatisticsViewModel.java
@@ -11,6 +11,7 @@ import com.antsapps.triples.backend.Period;
 public class ClassicStatisticsViewModel extends ViewModel {
   private final MediatorLiveData<ClassicStatistics> mStatistics = new MediatorLiveData<>();
   private final MutableLiveData<Period> mPeriod = new MutableLiveData<>(Period.ALL_TIME);
+  private final MutableLiveData<Boolean> mIncludeHinted = new MutableLiveData<>(false);
 
   private boolean mInitialized = false;
 
@@ -22,10 +23,12 @@ public class ClassicStatisticsViewModel extends ViewModel {
 
     mStatistics.addSource(application.getClassicGamesLiveData(), games -> update(application));
     mStatistics.addSource(mPeriod, period -> update(application));
+    mStatistics.addSource(mIncludeHinted, includeHinted -> update(application));
   }
 
   private void update(Application application) {
-    mStatistics.setValue(application.getClassicStatistics(mPeriod.getValue(), false));
+    mStatistics.setValue(
+        application.getClassicStatistics(mPeriod.getValue(), mIncludeHinted.getValue()));
   }
 
   public LiveData<ClassicStatistics> getStatistics() {
@@ -34,5 +37,9 @@ public class ClassicStatisticsViewModel extends ViewModel {
 
   public void setPeriod(Period period) {
     mPeriod.setValue(period);
+  }
+
+  public void setIncludeHinted(boolean includeHinted) {
+    mIncludeHinted.setValue(includeHinted);
   }
 }

--- a/app/src/main/java/com/antsapps/triples/stats/StatisticsSelectorView.java
+++ b/app/src/main/java/com/antsapps/triples/stats/StatisticsSelectorView.java
@@ -24,6 +24,10 @@ class StatisticsSelectorView extends FrameLayout {
     void onPeriodChange(Period period);
   }
 
+  interface OnIncludeHintedChangeListener {
+    void onIncludeHintedChange(boolean includeHinted);
+  }
+
   private static final long MS_PER_DAY = TimeUnit.DAYS.toMillis(1);
 
   private static final Map<String, Period> PERIODS = Maps.newLinkedHashMap();
@@ -31,6 +35,7 @@ class StatisticsSelectorView extends FrameLayout {
   private Period mCurrentPeriod;
 
   private OnPeriodChangeListener mOnPeriodChangeListener;
+  private OnIncludeHintedChangeListener mOnIncludeHintedChangeListener;
 
   public StatisticsSelectorView(Context context) {
     this(context, null);
@@ -48,6 +53,17 @@ class StatisticsSelectorView extends FrameLayout {
     View v = inflater.inflate(R.layout.stats_selector, this);
 
     initSpinner();
+    initCheckbox();
+  }
+
+  private void initCheckbox() {
+    android.widget.CheckBox includeHintedCheckbox = findViewById(R.id.include_hinted_checkbox);
+    includeHintedCheckbox.setOnCheckedChangeListener(
+        (buttonView, isChecked) -> {
+          if (mOnIncludeHintedChangeListener != null) {
+            mOnIncludeHintedChangeListener.onIncludeHintedChange(isChecked);
+          }
+        });
   }
 
   private void initSpinner() {
@@ -100,6 +116,10 @@ class StatisticsSelectorView extends FrameLayout {
 
   public void setOnPeriodChangeListener(OnPeriodChangeListener listener) {
     mOnPeriodChangeListener = listener;
+  }
+
+  public void setOnIncludeHintedChangeListener(OnIncludeHintedChangeListener listener) {
+    mOnIncludeHintedChangeListener = listener;
   }
 
   protected void setAccentColor(int accentColor) {

--- a/app/src/main/res/layout/stats_selector.xml
+++ b/app/src/main/res/layout/stats_selector.xml
@@ -18,8 +18,17 @@
 
   <Spinner
     android:id="@+id/period_spinner"
-    android:layout_width="wrap_content"
+    android:layout_width="0dp"
+    android:layout_weight="1"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical" />
+
+  <CheckBox
+    android:id="@+id/include_hinted_checkbox"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:text="@string/include_hinted_games"
+    android:textSize="12sp" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
   <string name="past_10_games">Past 10 games</string>
   <string name="past_50_games">Past 50 games</string>
   <string name="statistics_for">STATISTICS FOR</string>
+  <string name="include_hinted_games">Include hinted</string>
   <string name="settings">Settings</string>
   <string name="date_played">DATE PLAYED</string>
   <string name="time_taken">TIME TAKEN</string>

--- a/app/src/test/java/com/antsapps/triples/stats/IncludeHintedStatisticsTest.java
+++ b/app/src/test/java/com/antsapps/triples/stats/IncludeHintedStatisticsTest.java
@@ -1,0 +1,100 @@
+package com.antsapps.triples.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.test.core.app.ApplicationProvider;
+import com.antsapps.triples.BaseRobolectricTest;
+import com.antsapps.triples.backend.Application;
+import com.antsapps.triples.backend.ArcadeGame;
+import com.antsapps.triples.backend.ArcadeStatistics;
+import com.antsapps.triples.backend.Card;
+import com.antsapps.triples.backend.ClassicGame;
+import com.antsapps.triples.backend.ClassicStatistics;
+import com.google.common.collect.ImmutableList;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.shadows.ShadowLooper;
+
+public class IncludeHintedStatisticsTest extends BaseRobolectricTest {
+
+  private Application mApplication;
+  private ClassicStatisticsViewModel mClassicViewModel;
+  private ArcadeStatisticsViewModel mArcadeViewModel;
+
+  @Before
+  public void setUp() {
+    mApplication = Application.getInstance(ApplicationProvider.getApplicationContext());
+    mApplication.clearAllData();
+    mClassicViewModel = new ClassicStatisticsViewModel();
+    mClassicViewModel.init(mApplication);
+    mArcadeViewModel = new ArcadeStatisticsViewModel();
+    mArcadeViewModel.init(mApplication);
+  }
+
+  private static class StubRenderer implements com.antsapps.triples.backend.Game.GameRenderer {
+    @Override
+    public void updateCardsInPlay(ImmutableList<Card> newCards) {}
+
+    @Override
+    public void addHint(Card card) {}
+
+    @Override
+    public void clearHintedCards() {}
+
+    @Override
+    public void clearSelectedCards() {}
+
+    @Override
+    public Set<Card> getSelectedCards() {
+      return java.util.Collections.emptySet();
+    }
+  }
+
+  @Test
+  public void classicStatistics_includeHinted() {
+    AtomicReference<ClassicStatistics> statsRef = new AtomicReference<>();
+    mClassicViewModel.getStatistics().observeForever(statsRef::set);
+
+    ClassicGame game = ClassicGame.createFromSeed(1234L);
+    game.setGameRenderer(new StubRenderer());
+    game.finish();
+    game.addHint(); // This sets mHintsUsed = true
+    mApplication.addClassicGame(game);
+
+    ShadowLooper.idleMainLooper();
+    assertThat(statsRef.get().getNumGames()).isEqualTo(0);
+
+    mClassicViewModel.setIncludeHinted(true);
+    ShadowLooper.idleMainLooper();
+    assertThat(statsRef.get().getNumGames()).isEqualTo(1);
+
+    mClassicViewModel.setIncludeHinted(false);
+    ShadowLooper.idleMainLooper();
+    assertThat(statsRef.get().getNumGames()).isEqualTo(0);
+  }
+
+  @Test
+  public void arcadeStatistics_includeHinted() {
+    AtomicReference<ArcadeStatistics> statsRef = new AtomicReference<>();
+    mArcadeViewModel.getStatistics().observeForever(statsRef::set);
+
+    ArcadeGame game = ArcadeGame.createFromSeed(1234L);
+    game.setGameRenderer(new StubRenderer());
+    game.finish();
+    game.addHint(); // This sets mHintsUsed = true
+    mApplication.addArcadeGame(game);
+
+    ShadowLooper.idleMainLooper();
+    assertThat(statsRef.get().getNumGames()).isEqualTo(0);
+
+    mArcadeViewModel.setIncludeHinted(true);
+    ShadowLooper.idleMainLooper();
+    assertThat(statsRef.get().getNumGames()).isEqualTo(1);
+
+    mArcadeViewModel.setIncludeHinted(false);
+    ShadowLooper.idleMainLooper();
+    assertThat(statsRef.get().getNumGames()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
This change adds a "Include hinted" toggle to the Classic and Arcade statistics pages. By default, hinted games are excluded from the statistics. When the toggle is enabled, the statistics summary (averages, best times, etc.) and the list of games are updated to include games where hints were used. This is achieved by updating the respective ViewModels to observe the toggle state and requesting filtered statistics from the Application backend accordingly. Logic in the statistics classes was also updated to correctly process all games in the provided list when the include flag is active.

---
*PR created automatically by Jules for task [1294964253449432365](https://jules.google.com/task/1294964253449432365) started by @amorris13*