### PR TITLE
Add canonical FakeGameRenderer for testing

### DIFF
--- a/app/src/test/java/com/antsapps/triples/MainViewModelTest.java
+++ b/app/src/test/java/com/antsapps/triples/MainViewModelTest.java
@@ -8,9 +8,8 @@ import com.antsapps.triples.backend.ArcadeGame;
 import com.antsapps.triples.backend.Card;
 import com.antsapps.triples.backend.ClassicGame;
 import com.antsapps.triples.backend.DailyGame;
+import com.antsapps.triples.backend.FakeGameRenderer;
 import com.antsapps.triples.backend.Game;
-import com.google.common.collect.ImmutableList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -22,25 +21,6 @@ public class MainViewModelTest extends BaseRobolectricTest {
 
   private Application mApplication;
   private MainViewModel mViewModel;
-
-  private static class TestRenderer implements Game.GameRenderer {
-    @Override
-    public void updateCardsInPlay(ImmutableList<Card> newCards) {}
-
-    @Override
-    public void addHint(Card card) {}
-
-    @Override
-    public void clearHintedCards() {}
-
-    @Override
-    public void clearSelectedCards() {}
-
-    @Override
-    public Set<Card> getSelectedCards() {
-      return Collections.emptySet();
-    }
-  }
 
   @Before
   public void setUp() {
@@ -55,7 +35,7 @@ public class MainViewModelTest extends BaseRobolectricTest {
     mViewModel.getClassicResumeState().observeForever(state::set);
 
     ClassicGame game = ClassicGame.createFromSeed(1234L);
-    game.setGameRenderer(new TestRenderer());
+    game.setGameRenderer(new FakeGameRenderer());
     game.begin();
     // Find a valid triple from the cards in play
     List<Set<Card>> allTriples = Game.getAllValidTriples(game.getCardsInPlay());
@@ -76,7 +56,7 @@ public class MainViewModelTest extends BaseRobolectricTest {
     mViewModel.getClassicResumeState().observeForever(state::set);
 
     ClassicGame game = ClassicGame.createFromSeed(1234L);
-    game.setGameRenderer(new TestRenderer());
+    game.setGameRenderer(new FakeGameRenderer());
     game.begin();
     mApplication.addClassicGame(game);
 
@@ -92,7 +72,7 @@ public class MainViewModelTest extends BaseRobolectricTest {
     mViewModel.getArcadeResumeState().observeForever(state::set);
 
     ArcadeGame game = ArcadeGame.createFromSeed(1234L);
-    game.setGameRenderer(new TestRenderer());
+    game.setGameRenderer(new FakeGameRenderer());
     game.begin();
     // Find a valid triple from the cards in play
     List<Set<Card>> allTriples = Game.getAllValidTriples(game.getCardsInPlay());
@@ -113,7 +93,7 @@ public class MainViewModelTest extends BaseRobolectricTest {
     mViewModel.getDailyState().observeForever(state::set);
 
     DailyGame todayGame = mApplication.getDailyGameForDate(DailyGame.Day.forToday());
-    todayGame.setGameRenderer(new TestRenderer());
+    todayGame.setGameRenderer(new FakeGameRenderer());
     todayGame.begin();
     // Find a valid triple from the cards in play
     List<Set<Card>> allTriples = Game.getAllValidTriples(todayGame.getCardsInPlay());

--- a/app/src/test/java/com/antsapps/triples/NavigationTest.java
+++ b/app/src/test/java/com/antsapps/triples/NavigationTest.java
@@ -15,10 +15,9 @@ import com.antsapps.triples.backend.ArcadeGame;
 import com.antsapps.triples.backend.Card;
 import com.antsapps.triples.backend.ClassicGame;
 import com.antsapps.triples.backend.DailyGame;
+import com.antsapps.triples.backend.FakeGameRenderer;
 import com.antsapps.triples.backend.Game;
 import com.antsapps.triples.backend.ZenGame;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -269,25 +268,7 @@ public class NavigationTest extends BaseRobolectricTest {
 
             // Add a game in progress reactively
             ClassicGame game = ClassicGame.createFromSeed(12345L);
-            game.setGameRenderer(
-                new Game.GameRenderer() {
-                  @Override
-                  public void updateCardsInPlay(ImmutableList<Card> newCards) {}
-
-                  @Override
-                  public void addHint(Card card) {}
-
-                  @Override
-                  public void clearHintedCards() {}
-
-                  @Override
-                  public void clearSelectedCards() {}
-
-                  @Override
-                  public java.util.Set<Card> getSelectedCards() {
-                    return Sets.newHashSet();
-                  }
-                });
+            game.setGameRenderer(new FakeGameRenderer());
             game.begin();
             java.util.Set<Card> triple = game.getAllValidTriples(game.getCardsInPlay()).get(0);
             game.commitTriple(triple.toArray(new Card[0]));
@@ -339,25 +320,7 @@ public class NavigationTest extends BaseRobolectricTest {
 
             // Start a daily game and find a triple
             DailyGame game = app.getDailyGameForDate(DailyGame.Day.forToday());
-            game.setGameRenderer(
-                new Game.GameRenderer() {
-                  @Override
-                  public void updateCardsInPlay(ImmutableList<Card> newCards) {}
-
-                  @Override
-                  public void addHint(Card card) {}
-
-                  @Override
-                  public void clearHintedCards() {}
-
-                  @Override
-                  public void clearSelectedCards() {}
-
-                  @Override
-                  public java.util.Set<Card> getSelectedCards() {
-                    return Sets.newHashSet();
-                  }
-                });
+            game.setGameRenderer(new FakeGameRenderer());
             java.util.Set<Card> triple = game.getAllValidTriples(game.getCardsInPlay()).get(0);
             game.commitTriple(triple.toArray(new Card[0]));
             app.saveDailyGame(game);

--- a/app/src/test/java/com/antsapps/triples/PersistenceTest.java
+++ b/app/src/test/java/com/antsapps/triples/PersistenceTest.java
@@ -1,12 +1,12 @@
 package com.antsapps.triples;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.mock;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 import com.antsapps.triples.backend.Application;
 import com.antsapps.triples.backend.ClassicGame;
+import com.antsapps.triples.backend.FakeGameRenderer;
 import com.antsapps.triples.backend.Game;
 import java.util.List;
 import org.junit.Test;
@@ -20,7 +20,7 @@ public class PersistenceTest extends BaseRobolectricTest {
 
     // 1. Create and add a game
     ClassicGame game = ClassicGame.createFromSeed(54321L);
-    game.setGameRenderer(mock(Game.GameRenderer.class)); // prevent NPE if commitTriple calls it
+    game.setGameRenderer(new FakeGameRenderer()); // prevent NPE if commitTriple calls it
     app.addClassicGame(game);
     long gameId = game.getId();
     assertThat(gameId).isNotEqualTo(-1);

--- a/app/src/test/java/com/antsapps/triples/backend/ArcadeGameTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/ArcadeGameTest.java
@@ -13,25 +13,7 @@ public class ArcadeGameTest extends BaseRobolectricTest {
   @Test
   public void testCommitTripleIncrementsOnce() {
     ArcadeGame game = ArcadeGame.createFromSeed(12345L);
-    game.setGameRenderer(
-        new Game.GameRenderer() {
-          @Override
-          public void updateCardsInPlay(com.google.common.collect.ImmutableList<Card> newCards) {}
-
-          @Override
-          public void addHint(Card card) {}
-
-          @Override
-          public void clearHintedCards() {}
-
-          @Override
-          public void clearSelectedCards() {}
-
-          @Override
-          public Set<Card> getSelectedCards() {
-            return new java.util.HashSet<>();
-          }
-        });
+    game.setGameRenderer(new FakeGameRenderer());
 
     List<Card> cardsInPlay = game.getCardsInPlay();
     List<Set<Card>> validTriples = Game.getAllValidTriples(cardsInPlay);

--- a/app/src/test/java/com/antsapps/triples/backend/DailyGameHintTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/DailyGameHintTest.java
@@ -2,9 +2,6 @@ package com.antsapps.triples.backend;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
-import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -12,50 +9,22 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DailyGameHintTest {
 
-  private static class DummyRenderer implements Game.GameRenderer {
-    Set<Card> selected = Sets.newHashSet();
-    Set<Card> hinted = Sets.newHashSet();
-
-    @Override
-    public void updateCardsInPlay(ImmutableList<Card> newCards) {}
-
-    @Override
-    public void addHint(Card card) {
-      hinted.add(card);
-    }
-
-    @Override
-    public void clearHintedCards() {
-      hinted.clear();
-    }
-
-    @Override
-    public Set<Card> getSelectedCards() {
-      return selected;
-    }
-
-    @Override
-    public void clearSelectedCards() {
-      selected.clear();
-    }
-  }
-
   @Test
   public void addHint_hintsOnlyOneCardAtATime() {
     DailyGame game = DailyGame.createFromDay(new DailyGame.Day(2026, 03, 11));
-    DummyRenderer renderer = new DummyRenderer();
+    FakeGameRenderer renderer = new FakeGameRenderer();
     game.setGameRenderer(renderer);
 
     game.addHint();
-    assertThat(renderer.hinted).hasSize(1);
+    assertThat(renderer.mHintedCards).hasSize(1);
 
     game.addHint();
-    assertThat(renderer.hinted).hasSize(2);
+    assertThat(renderer.mHintedCards).hasSize(2);
 
     game.addHint();
-    assertThat(renderer.hinted).hasSize(3);
+    assertThat(renderer.mHintedCards).hasSize(3);
 
     // Verify it's a valid triple
-    assertThat(Game.isValidTriple(renderer.hinted)).isTrue();
+    assertThat(Game.isValidTriple(renderer.mHintedCards)).isTrue();
   }
 }

--- a/app/src/test/java/com/antsapps/triples/backend/DailyGameTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/DailyGameTest.java
@@ -2,8 +2,6 @@ package com.antsapps.triples.backend;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
@@ -12,25 +10,6 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class DailyGameTest {
-
-  private static class TestRenderer implements Game.GameRenderer {
-    @Override
-    public void updateCardsInPlay(ImmutableList<Card> newCards) {}
-
-    @Override
-    public void addHint(Card card) {}
-
-    @Override
-    public void clearHintedCards() {}
-
-    @Override
-    public Set<Card> getSelectedCards() {
-      return Collections.emptySet();
-    }
-
-    @Override
-    public void clearSelectedCards() {}
-  }
 
   @Test
   public void createFromDay_isDeterministic() {
@@ -52,7 +31,7 @@ public class DailyGameTest {
   @Test
   public void commitTriple_updatesFoundCount() {
     DailyGame game = DailyGame.createFromDay(new DailyGame.Day(2026, 03, 11));
-    game.setGameRenderer(new TestRenderer());
+    game.setGameRenderer(new FakeGameRenderer());
     game.begin();
 
     List<Card> cards = game.getCardsInPlay();
@@ -68,7 +47,7 @@ public class DailyGameTest {
   @Test
   public void commitTriple_sameTripleTwice_doesNotIncrement() {
     DailyGame game = DailyGame.createFromDay(new DailyGame.Day(2026, 03, 11));
-    game.setGameRenderer(new TestRenderer());
+    game.setGameRenderer(new FakeGameRenderer());
     game.begin();
 
     List<Card> cards = game.getCardsInPlay();
@@ -84,7 +63,7 @@ public class DailyGameTest {
   @Test
   public void commitAllTriples_finishesGame() {
     DailyGame game = DailyGame.createFromDay(new DailyGame.Day(2026, 03, 11));
-    game.setGameRenderer(new TestRenderer());
+    game.setGameRenderer(new FakeGameRenderer());
     game.begin();
 
     List<Card> cards = game.getCardsInPlay();

--- a/app/src/test/java/com/antsapps/triples/backend/FakeGameRenderer.java
+++ b/app/src/test/java/com/antsapps/triples/backend/FakeGameRenderer.java
@@ -1,0 +1,39 @@
+package com.antsapps.triples.backend;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import java.util.Set;
+
+/** Canonical fake implementation of {@link Game.GameRenderer} for testing. */
+public class FakeGameRenderer implements Game.GameRenderer {
+  public ImmutableList<Card> mCardsInPlay = ImmutableList.of();
+  public final Set<Card> mSelectedCards = Sets.newHashSet();
+  public final Set<Card> mHintedCards = Sets.newHashSet();
+
+  @Override
+  public void updateCardsInPlay(ImmutableList<Card> newCards) {
+    mCardsInPlay = newCards;
+  }
+
+  @Override
+  public void addHint(Card card) {
+    mHintedCards.add(card);
+    // Mimic CardsView.addHint logic: unselect any card that is not hinted.
+    mSelectedCards.retainAll(mHintedCards);
+  }
+
+  @Override
+  public void clearHintedCards() {
+    mHintedCards.clear();
+  }
+
+  @Override
+  public void clearSelectedCards() {
+    mSelectedCards.clear();
+  }
+
+  @Override
+  public Set<Card> getSelectedCards() {
+    return mSelectedCards;
+  }
+}

--- a/app/src/test/java/com/antsapps/triples/backend/GameTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/GameTest.java
@@ -122,25 +122,7 @@ public class GameTest {
             return "Test";
           }
         };
-    game.setGameRenderer(
-        new Game.GameRenderer() {
-          @Override
-          public void updateCardsInPlay(ImmutableList<Card> newCards) {}
-
-          @Override
-          public void addHint(Card card) {}
-
-          @Override
-          public void clearHintedCards() {}
-
-          @Override
-          public void clearSelectedCards() {}
-
-          @Override
-          public Set<Card> getSelectedCards() {
-            return Collections.emptySet();
-          }
-        });
+    game.setGameRenderer(new FakeGameRenderer());
 
     // We can't guarantee a shuffle will change order with only 4 cards, but it usually does.
     // To be more robust, we check that it still contains the same cards.

--- a/app/src/test/java/com/antsapps/triples/backend/HintTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/HintTest.java
@@ -2,12 +2,9 @@ package com.antsapps.triples.backend;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -40,36 +37,6 @@ public class HintTest {
     }
   }
 
-  private static class DummyRenderer implements Game.GameRenderer {
-    Set<Card> selected = Sets.newHashSet();
-    Set<Card> hinted = Sets.newHashSet();
-
-    @Override
-    public void updateCardsInPlay(ImmutableList<Card> newCards) {}
-
-    @Override
-    public void addHint(Card card) {
-      hinted.add(card);
-      // Mimic CardsView.addHint logic
-      selected.retainAll(hinted);
-    }
-
-    @Override
-    public void clearHintedCards() {
-      hinted.clear();
-    }
-
-    @Override
-    public Set<Card> getSelectedCards() {
-      return selected;
-    }
-
-    @Override
-    public void clearSelectedCards() {
-      selected.clear();
-    }
-  }
-
   @Test
   public void addHint_withSelectedCardInTriple_hintsThatTriple() {
     Card c1 = new Card(0, 0, 0, 0);
@@ -83,16 +50,16 @@ public class HintTest {
 
     Deck deck = new Deck(Lists.<Card>newArrayList());
     TestGame game = new TestGame(cardsInPlay, deck);
-    DummyRenderer renderer = new DummyRenderer();
+    FakeGameRenderer renderer = new FakeGameRenderer();
     game.setGameRenderer(renderer);
 
     // User selected c1, which is part of triple {c1, c2, c3}
-    renderer.selected.add(c1);
+    renderer.mSelectedCards.add(c1);
 
     game.addHint();
 
     // c1 should be hinted (to stay selected)
-    assertThat(renderer.hinted).contains(c1);
+    assertThat(renderer.mHintedCards).contains(c1);
   }
 
   @Test
@@ -107,16 +74,16 @@ public class HintTest {
 
     Deck deck = new Deck(Lists.<Card>newArrayList());
     TestGame game = new TestGame(cardsInPlay, deck);
-    DummyRenderer renderer = new DummyRenderer();
+    FakeGameRenderer renderer = new FakeGameRenderer();
     game.setGameRenderer(renderer);
 
-    renderer.selected.add(c1);
+    renderer.mSelectedCards.add(c1);
 
     game.addHint(); // should hint c1
     game.addHint(); // should hint c2 or c3
     game.addHint(); // should hint the remaining one
 
-    assertThat(renderer.hinted).containsExactly(c1, c2, c3);
+    assertThat(renderer.mHintedCards).containsExactly(c1, c2, c3);
   }
 
   @Test
@@ -132,16 +99,16 @@ public class HintTest {
 
     Deck deck = new Deck(Lists.<Card>newArrayList());
     TestGame game = new TestGame(cardsInPlay, deck);
-    DummyRenderer renderer = new DummyRenderer();
+    FakeGameRenderer renderer = new FakeGameRenderer();
     game.setGameRenderer(renderer);
 
     // User selected c1 (part of triple) and c4 (not part of that triple)
-    renderer.selected.add(c1);
-    renderer.selected.add(c4);
+    renderer.mSelectedCards.add(c1);
+    renderer.mSelectedCards.add(c4);
 
     game.addHint(); // should hint c1 and unselect c4
 
-    assertThat(renderer.hinted).contains(c1);
-    assertThat(renderer.selected).containsExactly(c1);
+    assertThat(renderer.mHintedCards).contains(c1);
+    assertThat(renderer.mSelectedCards).containsExactly(c1);
   }
 }

--- a/app/src/test/java/com/antsapps/triples/backend/ZenGameTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/ZenGameTest.java
@@ -4,38 +4,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import org.junit.Test;
 
 public class ZenGameTest {
 
-  private static class TestRenderer implements Game.GameRenderer {
-    @Override
-    public void updateCardsInPlay(ImmutableList<Card> newCards) {}
-
-    @Override
-    public void addHint(Card card) {}
-
-    @Override
-    public void clearHintedCards() {}
-
-    @Override
-    public Set<Card> getSelectedCards() {
-      return Collections.emptySet();
-    }
-
-    @Override
-    public void clearSelectedCards() {}
-  }
-
   @Test
   public void testZenGameRecycling() {
     ZenGame game = ZenGame.createFromSeed(12345L, false);
-    game.setGameRenderer(new TestRenderer());
+    game.setGameRenderer(new FakeGameRenderer());
     game.begin();
 
     int initialDeckSize = game.mDeck.getCardsRemaining();

--- a/app/src/test/java/com/antsapps/triples/stats/IncludeHintedStatisticsTest.java
+++ b/app/src/test/java/com/antsapps/triples/stats/IncludeHintedStatisticsTest.java
@@ -7,11 +7,9 @@ import com.antsapps.triples.BaseRobolectricTest;
 import com.antsapps.triples.backend.Application;
 import com.antsapps.triples.backend.ArcadeGame;
 import com.antsapps.triples.backend.ArcadeStatistics;
-import com.antsapps.triples.backend.Card;
 import com.antsapps.triples.backend.ClassicGame;
 import com.antsapps.triples.backend.ClassicStatistics;
-import com.google.common.collect.ImmutableList;
-import java.util.Set;
+import com.antsapps.triples.backend.FakeGameRenderer;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,32 +31,13 @@ public class IncludeHintedStatisticsTest extends BaseRobolectricTest {
     mArcadeViewModel.init(mApplication);
   }
 
-  private static class StubRenderer implements com.antsapps.triples.backend.Game.GameRenderer {
-    @Override
-    public void updateCardsInPlay(ImmutableList<Card> newCards) {}
-
-    @Override
-    public void addHint(Card card) {}
-
-    @Override
-    public void clearHintedCards() {}
-
-    @Override
-    public void clearSelectedCards() {}
-
-    @Override
-    public Set<Card> getSelectedCards() {
-      return java.util.Collections.emptySet();
-    }
-  }
-
   @Test
   public void classicStatistics_includeHinted() {
     AtomicReference<ClassicStatistics> statsRef = new AtomicReference<>();
     mClassicViewModel.getStatistics().observeForever(statsRef::set);
 
     ClassicGame game = ClassicGame.createFromSeed(1234L);
-    game.setGameRenderer(new StubRenderer());
+    game.setGameRenderer(new FakeGameRenderer());
     game.finish();
     game.addHint(); // This sets mHintsUsed = true
     mApplication.addClassicGame(game);
@@ -81,7 +60,7 @@ public class IncludeHintedStatisticsTest extends BaseRobolectricTest {
     mArcadeViewModel.getStatistics().observeForever(statsRef::set);
 
     ArcadeGame game = ArcadeGame.createFromSeed(1234L);
-    game.setGameRenderer(new StubRenderer());
+    game.setGameRenderer(new FakeGameRenderer());
     game.finish();
     game.addHint(); // This sets mHintsUsed = true
     mApplication.addArcadeGame(game);


### PR DESCRIPTION
This change introduces a canonical `FakeGameRenderer` class to replace the numerous redundant and basic `GameRenderer` fake implementations scattered across the test suite. 

Key changes:
- **New class `FakeGameRenderer`**: Implements `Game.GameRenderer` with standard behavior for tracking cards in play, selected cards, and hinted cards. It correctly replicates the logic where adding a hint unselects non-hinted cards.
- **Widespread Refactoring**: Updated 10 test files to use the new `FakeGameRenderer`, removing local stub classes and simplifying test setup. 
- **Consistency**: Ensures all tests that interact with the renderer now use a consistent, well-defined behavior, making the test suite easier to maintain and reason about.

---
*PR created automatically by Jules for task [6002505245954948385](https://jules.google.com/task/6002505245954948385) started by @amorris13*