### PR TITLE
Show hundredths of a second for triple find statistics

### DIFF
--- a/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
+++ b/app/src/main/java/com/antsapps/triples/BaseGameActivity.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -332,11 +331,14 @@ public abstract class BaseGameActivity extends BaseTriplesActivity
   }
 
   protected static String formatElapsedTime(long elapsedMillis) {
-    long seconds = TimeUnit.MILLISECONDS.toSeconds(elapsedMillis);
-    if (seconds < 3600) {
-      return String.format("%d:%02d", seconds / 60, seconds % 60);
+    long hours = TimeUnit.MILLISECONDS.toHours(elapsedMillis);
+    long minutes = TimeUnit.MILLISECONDS.toMinutes(elapsedMillis) % 60;
+    long seconds = TimeUnit.MILLISECONDS.toSeconds(elapsedMillis) % 60;
+    long hundredths = (elapsedMillis % 1000) / 10;
+    if (hours == 0) {
+      return String.format("%d:%02d.%02d", minutes, seconds, hundredths);
     } else {
-      return DateUtils.formatElapsedTime(seconds);
+      return String.format("%d:%02d:%02d.%02d", hours, minutes, seconds, hundredths);
     }
   }
 

--- a/app/src/test/java/com/antsapps/triples/BaseGameActivityTest.java
+++ b/app/src/test/java/com/antsapps/triples/BaseGameActivityTest.java
@@ -1,0 +1,19 @@
+package com.antsapps.triples;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+public class BaseGameActivityTest extends BaseRobolectricTest {
+
+  @Test
+  public void testFormatElapsedTime() {
+    // New behavior with hundredths of a second
+    assertThat(BaseGameActivity.formatElapsedTime(500)).isEqualTo("0:00.50");
+    assertThat(BaseGameActivity.formatElapsedTime(1500)).isEqualTo("0:01.50");
+    assertThat(BaseGameActivity.formatElapsedTime(61000)).isEqualTo("1:01.00");
+    assertThat(BaseGameActivity.formatElapsedTime(61123)).isEqualTo("1:01.12");
+    assertThat(BaseGameActivity.formatElapsedTime(3601000)).isEqualTo("1:00:01.00");
+    assertThat(BaseGameActivity.formatElapsedTime(3661123)).isEqualTo("1:01:01.12");
+  }
+}


### PR DESCRIPTION
Updated the elapsed time formatting logic in `BaseGameActivity` to include hundredths of a second. This change ensures that the fastest and slowest triple statistics displayed on the game completion screen provide more precise information to the user. I also added a comprehensive unit test suite to verify the formatting across various time ranges (sub-second, minutes, and hours).

---
*PR created automatically by Jules for task [12835607448843003836](https://jules.google.com/task/12835607448843003836) started by @amorris13*