### PR TITLE
Reorder game menu items to put play/pause on the left

### DIFF
--- a/app/src/main/res/menu/game.xml
+++ b/app/src/main/res/menu/game.xml
@@ -3,16 +3,6 @@
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <item
-      android:id="@+id/hint"
-      android:icon="@drawable/ic_lightbulb"
-      app:showAsAction="always"
-      android:title="@string/hint" />
-  <item
-      android:id="@+id/shuffle"
-      android:icon="@drawable/ic_shuffle"
-      app:showAsAction="ifRoom"
-      android:title="@string/shuffle" />
-  <item
       android:id="@+id/pause"
       android:icon="@drawable/ic_pause"
       app:showAsAction="always"
@@ -22,6 +12,16 @@
       android:icon="@drawable/ic_play"
       app:showAsAction="always"
       android:title="@string/play" />
+  <item
+      android:id="@+id/hint"
+      android:icon="@drawable/ic_lightbulb"
+      app:showAsAction="always"
+      android:title="@string/hint" />
+  <item
+      android:id="@+id/shuffle"
+      android:icon="@drawable/ic_shuffle"
+      app:showAsAction="ifRoom"
+      android:title="@string/shuffle" />
   <item
       android:id="@+id/help"
       android:icon="@drawable/ic_help"


### PR DESCRIPTION
Moved the `pause` and `play` menu items to the top of the `game.xml` menu resource file to ensure they are the leftmost items in the game activity's action bar. verified the change via file inspection and ensured all unit tests pass. addressed a code review concern by removing accidental license file inclusions.

---
*PR created automatically by Jules for task [7642809399903644255](https://jules.google.com/task/7642809399903644255) started by @amorris13*