### PR TITLE
Improve CI robustness and manual triggers

### DIFF
--- a/.github/workflows/pr_distribution.yml
+++ b/.github/workflows/pr_distribution.yml
@@ -3,6 +3,8 @@ name: PR Distribution
 on:
   pull_request:
     branches: [ master ]
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   distribute:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
I have improved the GitHub Actions configuration to ensure more reliable triggering of tests and style checks.

Key changes:
1.  **Added `workflow_dispatch`**: You can now manually trigger the "Test" and "PR Distribution" workflows from the GitHub Actions tab. This is useful if a run fails to trigger automatically or needs to be re-run without pushing a new commit.
2.  **Explicit `pull_request` types**: I added `opened`, `reopened`, `synchronize`, and `ready_for_review` to the triggers. Specifically, `ready_for_review` ensures that when a Draft PR is marked as ready, the tests are kicked off. `synchronize` is the event for new commits to an existing PR.
3.  **Root Cause Analysis**: I also identified that GitHub Actions will not trigger if a commit is pushed by another action using the default `GITHUB_TOKEN`, which is a common reason for "missing" triggers in automated environments.

I verified the syntax and ran local tests (`./gradlew spotlessCheck test`) to ensure the project remains in a healthy state.

---
*PR created automatically by Jules for task [17976924332579763905](https://jules.google.com/task/17976924332579763905) started by @amorris13*