### PR TITLE
Invert classic game statistics percentiles

### DIFF
--- a/app/src/main/java/com/antsapps/triples/backend/ClassicStatistics.java
+++ b/app/src/main/java/com/antsapps/triples/backend/ClassicStatistics.java
@@ -73,10 +73,10 @@ public class ClassicStatistics extends Statistics {
       times.add(game.getTimeElapsed());
     }
     Collections.sort(times);
-    mP25 = times.get((int) (times.size() * 0.25));
+    mP25 = times.get((int) (times.size() * 0.75));
     mP50 = times.get((int) (times.size() * 0.50));
-    mP75 = times.get((int) (times.size() * 0.75));
-    mP95 = times.get((int) (times.size() * 0.95));
+    mP75 = times.get((int) (times.size() * 0.25));
+    mP95 = times.get((int) (times.size() * 0.05));
   }
 
   public long getFastestTime() {

--- a/app/src/main/java/com/antsapps/triples/backend/ClassicStatistics.java
+++ b/app/src/main/java/com/antsapps/triples/backend/ClassicStatistics.java
@@ -72,11 +72,11 @@ public class ClassicStatistics extends Statistics {
     for (Game game : mGamesInPeriod) {
       times.add(game.getTimeElapsed());
     }
-    Collections.sort(times);
-    mP25 = times.get((int) (times.size() * 0.75));
+    Collections.sort(times, Collections.reverseOrder());
+    mP25 = times.get((int) (times.size() * 0.25));
     mP50 = times.get((int) (times.size() * 0.50));
-    mP75 = times.get((int) (times.size() * 0.25));
-    mP95 = times.get((int) (times.size() * 0.05));
+    mP75 = times.get((int) (times.size() * 0.75));
+    mP95 = times.get((int) (times.size() * 0.95));
   }
 
   public long getFastestTime() {

--- a/app/src/test/java/com/antsapps/triples/backend/ClassicStatisticsTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/ClassicStatisticsTest.java
@@ -1,0 +1,55 @@
+package com.antsapps.triples.backend;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ClassicStatisticsTest {
+
+  private static ClassicGame createGame(long timeElapsed) {
+    return new ClassicGame(
+        0,
+        0,
+        ImmutableList.<Card>of(),
+        ImmutableList.<Long>of(),
+        new Deck(new Random(0)),
+        timeElapsed,
+        new Date(),
+        Game.GameState.COMPLETED,
+        false,
+        ImmutableList.<Set<Card>>of());
+  }
+
+  @Test
+  public void percentiles_areCorrectlyCalculated() {
+    List<ClassicGame> games = new ArrayList<>();
+    // 100 games with times 1, 2, ..., 100 seconds
+    for (int i = 1; i <= 100; i++) {
+      games.add(createGame(i * 1000L));
+    }
+
+    ClassicStatistics stats = new ClassicStatistics(games, Period.ALL_TIME, true);
+
+    // After fix:
+    // sorted ascending: 1000, 2000, ..., 100000
+    // size = 100
+    // p95 = index (100 * 0.05) = index 5 = 6000
+    // p75 = index (100 * 0.25) = index 25 = 26000
+    // p50 = index (100 * 0.50) = index 50 = 51000
+    // p25 = index (100 * 0.75) = index 75 = 76000
+
+    assertThat(stats.getP95()).isEqualTo(6000L);
+    assertThat(stats.getP75()).isEqualTo(26000L);
+    assertThat(stats.getP50()).isEqualTo(51000L);
+    assertThat(stats.getP25()).isEqualTo(76000L);
+  }
+}

--- a/app/src/test/java/com/antsapps/triples/backend/ClassicStatisticsTest.java
+++ b/app/src/test/java/com/antsapps/triples/backend/ClassicStatisticsTest.java
@@ -39,17 +39,16 @@ public class ClassicStatisticsTest {
 
     ClassicStatistics stats = new ClassicStatistics(games, Period.ALL_TIME, true);
 
-    // After fix:
-    // sorted ascending: 1000, 2000, ..., 100000
+    // List sorted descending: 100000, 99000, ..., 1000
     // size = 100
-    // p95 = index (100 * 0.05) = index 5 = 6000
-    // p75 = index (100 * 0.25) = index 25 = 26000
-    // p50 = index (100 * 0.50) = index 50 = 51000
-    // p25 = index (100 * 0.75) = index 75 = 76000
+    // p95 = index (100 * 0.95) = index 95 = 5000
+    // p75 = index (100 * 0.75) = index 75 = 25000
+    // p50 = index (100 * 0.50) = index 50 = 50000
+    // p25 = index (100 * 0.25) = index 25 = 75000
 
-    assertThat(stats.getP95()).isEqualTo(6000L);
-    assertThat(stats.getP75()).isEqualTo(26000L);
-    assertThat(stats.getP50()).isEqualTo(51000L);
-    assertThat(stats.getP25()).isEqualTo(76000L);
+    assertThat(stats.getP95()).isEqualTo(5000L);
+    assertThat(stats.getP75()).isEqualTo(25000L);
+    assertThat(stats.getP50()).isEqualTo(50000L);
+    assertThat(stats.getP25()).isEqualTo(75000L);
   }
 }


### PR DESCRIPTION
Modified ClassicStatistics.java to ensure that the 95th percentile corresponds to faster completion times (the top 5% of games) rather than slower ones. Added a unit test to verify the corrected percentile mapping.

---
*PR created automatically by Jules for task [2171848177475701017](https://jules.google.com/task/2171848177475701017) started by @amorris13*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected percentile calculations in game performance statistics so displayed 25th, 50th, 75th, and 95th percentile times now reflect the intended player timing values.

* **Tests**
  * Added deterministic tests validating percentile values across a representative set of game results to ensure future accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->